### PR TITLE
feat: display all asset balances with issuer in financials tab

### DIFF
--- a/web/src/app/projects/[slug]/page.tsx
+++ b/web/src/app/projects/[slug]/page.tsx
@@ -57,7 +57,12 @@ interface Averages {
 }
 
 interface FinancialSummary {
-	balances: {asset_code: string; balance: string}[];
+	balances: {
+		asset_type: string;
+		asset_code: string;
+		asset_issuer?: string;
+		balance: string;
+	}[];
 }
 
 function stellarExplorerBase(network?: string) {
@@ -853,9 +858,16 @@ export default function ProjectDetailPage({
 													key={i}
 													className="flex items-center justify-between bg-stardust/30 rounded-xl px-5 py-4"
 												>
-													<span className="font-medium text-moonlight">
-														{b.asset_code}
-													</span>
+													<div>
+														<span className="font-medium text-moonlight">
+															{b.asset_code}
+														</span>
+														{b.asset_issuer && (
+															<p className="text-xs text-ash font-mono mt-0.5">
+																Issuer: {b.asset_issuer.slice(0, 8)}...{b.asset_issuer.slice(-4)}
+															</p>
+														)}
+													</div>
 													<span className="font-mono text-plasma-bright font-semibold">
 														{Number(b.balance).toLocaleString()}
 													</span>

--- a/web/src/lib/stellarService.ts
+++ b/web/src/lib/stellarService.ts
@@ -11,6 +11,7 @@ export async function getAccountSummary(accountId: string) {
     balances: account.balances.map((b) => ({
       asset_type: b.asset_type,
       asset_code: "asset_code" in b ? b.asset_code : "XLM",
+      asset_issuer: "asset_issuer" in b ? b.asset_issuer : undefined,
       balance: b.balance,
     })),
     sequence: account.sequence,


### PR DESCRIPTION
## Summary

Closes #203

- `getAccountSummary` in `stellarService.ts` already returned all balances (XLM + non-native assets like USDC) but the `asset_issuer` field was not passed through — added it.
- Extended the `FinancialSummary` interface in the project detail page to include `asset_type` and optional `asset_issuer`.
- The financials tab now renders every balance from `getAccountSummary`, showing a truncated issuer address beneath the asset code for non-native assets (e.g. USDC). XLM rows are unchanged since native has no issuer.

## Test plan
- [ ] Project holding USDC: USDC appears alongside XLM in the Financials tab with issuer shown.
- [ ] Project with only XLM: displays correctly with no issuer line.
- [ ] Multiple non-native assets: all are shown.
