### PR TITLE
Add on-chain verified owner badge (#204)

### DIFF
--- a/web/src/app/api/projects/[id]/verify-owner/route.ts
+++ b/web/src/app/api/projects/[id]/verify-owner/route.ts
@@ -1,0 +1,83 @@
+import { Keypair, TransactionBuilder, Networks } from "@stellar/stellar-sdk";
+import firestore from "@/lib/firebase";
+import { projectsCol } from "@/lib/db";
+import { getAuthUser } from "@/lib/auth";
+export const dynamic = "force-dynamic";
+
+// Reuses the auth challenge collection used by /api/auth/challenge + /api/auth/wallet
+function challengesCol() { return firestore.collection("auth_challenges"); }
+
+export async function POST(
+  request: Request,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const auth = getAuthUser(request);
+  if (!auth) return Response.json({ error: "Unauthorized" }, { status: 401 });
+
+  const { id } = await params;
+  const ref = projectsCol.ref.doc(id);
+  const doc = await ref.get();
+  if (!doc.exists) return Response.json({ error: "Project not found" }, { status: 404 });
+
+  const project = doc.data()!;
+  if (project.user_id !== auth.userId && auth.role !== "admin") {
+    return Response.json({ error: "Forbidden" }, { status: 403 });
+  }
+
+  const publicKey = project.stellar_account_id as string | undefined;
+  if (!publicKey) {
+    return Response.json({ error: "Project has no Stellar account to verify" }, { status: 400 });
+  }
+
+  try {
+    const { signedXdr } = await request.json();
+    if (!signedXdr) {
+      return Response.json({ error: "signedXdr is required" }, { status: 400 });
+    }
+
+    // Retrieve and validate challenge (issued by /api/auth/challenge for this account)
+    const challengeDoc = await challengesCol().doc(publicKey).get();
+    if (!challengeDoc.exists) {
+      return Response.json({ error: "No challenge found. Request a new one." }, { status: 400 });
+    }
+
+    const challengeData = challengeDoc.data()!;
+    if (Date.now() > (challengeData.expires_at as number)) {
+      await challengesCol().doc(publicKey).delete();
+      return Response.json({ error: "Challenge expired. Request a new one." }, { status: 400 });
+    }
+
+    // Parse the signed transaction and verify the project account's signature
+    const transaction = TransactionBuilder.fromXDR(signedXdr, Networks.TESTNET);
+    const keypair = Keypair.fromPublicKey(publicKey);
+    const txHash = transaction.hash();
+
+    const signedByOwner = transaction.signatures.some((sig) => {
+      try {
+        return keypair.verify(txHash, sig.signature());
+      } catch {
+        return false;
+      }
+    });
+
+    if (!signedByOwner) {
+      return Response.json(
+        { error: "Invalid signature — challenge not signed by the project's Stellar account" },
+        { status: 401 }
+      );
+    }
+
+    // Clean up used challenge and persist the verified flag
+    await challengesCol().doc(publicKey).delete();
+    await ref.update({
+      owner_verified: true,
+      owner_verified_at: new Date().toISOString(),
+      updated_at: new Date().toISOString(),
+    });
+
+    return Response.json({ verified: true });
+  } catch (err) {
+    console.error("Verify owner error:", err);
+    return Response.json({ error: "Verification failed" }, { status: 500 });
+  }
+}

--- a/web/src/app/projects/[slug]/page.tsx
+++ b/web/src/app/projects/[slug]/page.tsx
@@ -26,6 +26,7 @@ interface Project {
 	stellar_account_id?: string;
 	stellar_contract_id?: string;
 	stellar_network?: string;
+	owner_verified?: boolean;
 	tags?: string;
 	website_url?: string;
 	github_url?: string;
@@ -87,6 +88,21 @@ function StellarAddressLink({address, type, network}: {address: string; type: "a
 	);
 }
 
+function VerifiedBadge() {
+	return (
+		<span
+			className="tag tag-aurora inline-flex items-center gap-1.5"
+			title="Owner proved control of the project's Stellar account by signing a challenge"
+		>
+			<svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" className="shrink-0">
+				<path d="M9 12l2 2 4-4" />
+				<path d="M12 3l7.5 4v5c0 4.5-3 8-7.5 9-4.5-1-7.5-4.5-7.5-9V7L12 3z" />
+			</svg>
+			Verified
+		</span>
+	);
+}
+
 /** Format a raw i128 stroop amount as a human-readable token string (6 dp). */
 function formatFee(stroops: bigint | null): string {
 	if (stroops === null) return "0.1 USDC";
@@ -129,6 +145,65 @@ export default function ProjectDetailPage({
 	const [ratingMsg, setRatingMsg] = useState("");
 	const [ratingStep, setRatingStep] = useState<"idle" | "onchain" | "saving">("idle");
 	const [lastTxHash, setLastTxHash] = useState<string | null>(null);
+
+	// Owner verification
+	const [verifying, setVerifying] = useState(false);
+	const [verifyMsg, setVerifyMsg] = useState("");
+
+	async function handleVerifyOwnership() {
+		if (!project || !project.stellar_account_id || !token) return;
+		setVerifying(true);
+		setVerifyMsg("");
+		try {
+			const { isConnected, requestAccess, getAddress, signTransaction } =
+				await import("@stellar/freighter-api");
+
+			const connResult = await isConnected();
+			if (connResult.error || !connResult.isConnected) {
+				throw new Error("Freighter wallet not found. Please install the Freighter extension.");
+			}
+
+			const accessResult = await requestAccess();
+			if (accessResult.error) throw new Error(accessResult.error.message || "Wallet access denied.");
+
+			const addrResult = await getAddress();
+			if (addrResult.error || !addrResult.address) throw new Error("Could not retrieve public key from wallet.");
+
+			if (addrResult.address !== project.stellar_account_id) {
+				throw new Error("Connected wallet does not match the project's Stellar account.");
+			}
+
+			// Reuse the auth challenge issuance for this account
+			const challengeRes = await fetch(`/api/auth/challenge?publicKey=${project.stellar_account_id}`);
+			const challengeData = await challengeRes.json();
+			if (!challengeRes.ok) throw new Error(challengeData.error || "Failed to get challenge");
+
+			const signResult = await signTransaction(challengeData.challengeXdr, {
+				networkPassphrase: challengeData.networkPassphrase,
+			});
+			if (signResult.error || !signResult.signedTxXdr) {
+				throw new Error("Failed to sign challenge with wallet.");
+			}
+
+			const res = await fetch(`/api/projects/${project.id}/verify-owner`, {
+				method: "POST",
+				headers: {
+					"Content-Type": "application/json",
+					Authorization: `Bearer ${token}`,
+				},
+				body: JSON.stringify({ signedXdr: signResult.signedTxXdr }),
+			});
+			const data = await res.json();
+			if (!res.ok) throw new Error(data.error || "Verification failed");
+
+			setProject((p) => (p ? { ...p, owner_verified: true } : p));
+			setVerifyMsg("Ownership verified!");
+		} catch (err) {
+			setVerifyMsg(err instanceof Error ? err.message : "Verification failed");
+		} finally {
+			setVerifying(false);
+		}
+	}
 
 	useEffect(() => {
 		fetch(`/api/projects/${slug}`)
@@ -295,6 +370,7 @@ export default function ProjectDetailPage({
 									Featured
 								</span>
 							)}
+							{project.owner_verified && <VerifiedBadge />}
 						</div>
 						<div className="flex items-center gap-3 mt-2 text-sm text-ash">
 							<span>by {project.username}</span>
@@ -503,6 +579,29 @@ export default function ProjectDetailPage({
 													<line x1="10" y1="14" x2="21" y2="3" />
 												</svg>
 											</a>
+											{/* Ownership verification */}
+											<div className="mt-3 flex items-center gap-3 flex-wrap">
+												{project.owner_verified ? (
+													<VerifiedBadge />
+												) : (
+													user &&
+													user.id === project.user_id && (
+														<button
+															onClick={handleVerifyOwnership}
+															disabled={verifying}
+															className="btn-ghost text-sm !py-1.5 inline-flex items-center gap-1.5 disabled:opacity-50"
+														>
+															<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+																<path d="M12 3l7.5 4v5c0 4.5-3 8-7.5 9-4.5-1-7.5-4.5-7.5-9V7L12 3z" />
+															</svg>
+															{verifying ? "Verifying…" : "Verify ownership"}
+														</button>
+													)
+												)}
+												{verifyMsg && (
+													<span className="text-xs text-ash">{verifyMsg}</span>
+												)}
+											</div>
 										</div>
 									)}
 									{project.stellar_contract_id && (

--- a/web/src/components/ProjectCard.tsx
+++ b/web/src/components/ProjectCard.tsx
@@ -16,6 +16,7 @@ interface ProjectCardProps {
     rating_count?: number;
     username?: string;
     logo_url?: string;
+    owner_verified?: boolean;
   };
   index?: number;
 }
@@ -63,9 +64,23 @@ export default function ProjectCard({ project, index = 0 }: ProjectCardProps) {
           {project.name[0]}
         </div>
         <div className="min-w-0 flex-1">
-          <h3 className="font-semibold text-starlight group-hover:text-nova-bright transition-colors truncate">
-            {project.name}
-          </h3>
+          <div className="flex items-center gap-1.5 min-w-0">
+            <h3 className="font-semibold text-starlight group-hover:text-nova-bright transition-colors truncate">
+              {project.name}
+            </h3>
+            {project.owner_verified && (
+              <span
+                className="shrink-0 text-aurora-bright"
+                title="Verified owner"
+                aria-label="Verified owner"
+              >
+                <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5">
+                  <path d="M9 12l2 2 4-4" />
+                  <path d="M12 3l7.5 4v5c0 4.5-3 8-7.5 9-4.5-1-7.5-4.5-7.5-9V7L12 3z" />
+                </svg>
+              </span>
+            )}
+          </div>
           {project.username && (
             <p className="text-xs text-ash mt-0.5">by {project.username}</p>
           )}


### PR DESCRIPTION
closes #204  

Summary

  Lets a project owner prove they control the project's Stellar account by signing a challenge, then displays a Verified badge across the app. Reuses the
  existing auth challenge/verification flow rather than introducing a new signing mechanism.

  Changes

  1. Verification API — web/src/app/api/projects/[id]/verify-owner/route.ts (new)
  - Requires auth and that the caller is the project owner (or admin).
  - Reuses the existing challenge issuance: the client fetches a challenge from /api/auth/challenge for the project's stellar_account_id, signs it, and
  POSTs the signed XDR here.
  - Verifies the signature against the project's Stellar account using the same pattern as /api/auth/wallet (parse XDR → keypair.verify(txHash, sig)).
  - On success, persists owner_verified: true (+ owner_verified_at) on the project document.

  2. Persisted flag
  - owner_verified is stored on the project doc and flows through the existing list/detail APIs (which spread the full document).

  3. Verified badge UI
  - Project detail page (projects/[slug]/page.tsx): a Verified badge next to the title, plus a Verify ownership button shown to the owner in the On-Chain
  Details section. The handler mirrors the connectWallet flow — connects Freighter, fetches the challenge, signs, and calls the verify endpoint. It also
  guards that the connected wallet matches the project's account.
  - Project card (components/ProjectCard.tsx): a shield-check icon beside the project name when verified.

  Acceptance criteria

  - ✅ Signing with the account's key sets the badge — server verifies the signature, persists the flag, and the UI updates immediately.
  - ✅ Wrong key fails verification — signature verification returns 401 and the flag is not set.

  Notes

  - Implemented entirely within the web/ workspace per project conventions.
  - Reuses the auth_challenges collection and challenge lifecycle (issuance, expiry, single-use cleanup) already used by wallet auth.

  ---