### PR TITLE
Notify submitters on project status change

### DIFF
--- a/web/data/supabase/005_add_notifications.sql
+++ b/web/data/supabase/005_add_notifications.sql
@@ -1,0 +1,21 @@
+create table if not exists public.notifications (
+  id uuid primary key default gen_random_uuid(),
+  user_id integer not null references public.users(numericId) on delete cascade,
+  project_id integer references public.projects(numericId) on delete cascade,
+  type text not null,
+  title text not null,
+  message text not null,
+  metadata jsonb not null default '{}'::jsonb,
+  read_at timestamptz,
+  created_at timestamptz not null default now()
+);
+
+create index if not exists notifications_user_created_idx
+  on public.notifications (user_id, created_at desc);
+
+alter table public.notifications enable row level security;
+
+drop policy if exists "Users can read own notifications" on public.notifications;
+create policy "Users can read own notifications"
+  on public.notifications for select
+  using (user_id = nullif(current_setting('request.jwt.claims', true)::jsonb ->> 'user_id', '')::integer);

--- a/web/src/app/api/projects/[id]/approve/route.ts
+++ b/web/src/app/api/projects/[id]/approve/route.ts
@@ -1,4 +1,5 @@
 import { projectsCol } from "@/lib/db";
+import { notifyProjectStatusChange } from "@/lib/notifications";
 import { getAuthUser } from "@/lib/auth";
 export const dynamic = "force-dynamic";
 
@@ -21,7 +22,15 @@ export async function PUT(
     const featured = body.featured ? 1 : 0;
     const status = featured ? "featured" : "approved";
 
+    const previous = doc.data()!;
     await ref.update({ status, featured, updated_at: new Date().toISOString() });
+    await notifyProjectStatusChange({
+      projectId: previous.numericId as number,
+      projectName: previous.name as string,
+      userId: previous.user_id as number,
+      fromStatus: previous.status as string,
+      toStatus: status,
+    });
     const updated = await ref.get();
     return Response.json({ project: { ...updated.data(), id: updated.data()!.numericId } });
   } catch (err) {

--- a/web/src/app/api/projects/[id]/delist/route.ts
+++ b/web/src/app/api/projects/[id]/delist/route.ts
@@ -1,4 +1,5 @@
 import { projectsCol } from "@/lib/db";
+import { notifyProjectStatusChange } from "@/lib/notifications";
 import { getAuthUser } from "@/lib/auth";
 export const dynamic = "force-dynamic";
 
@@ -18,11 +19,21 @@ export async function PUT(
 
   try {
     const body = await request.json().catch(() => ({}));
+    const previous = doc.data()!;
+    const delistReason = body.reason || "Delisted by admin";
     await ref.update({
       status: "delisted",
       featured: 0,
-      rejection_reason: body.reason || "Delisted by admin",
+      rejection_reason: delistReason,
       updated_at: new Date().toISOString(),
+    });
+    await notifyProjectStatusChange({
+      projectId: previous.numericId as number,
+      projectName: previous.name as string,
+      userId: previous.user_id as number,
+      fromStatus: previous.status as string,
+      toStatus: "delisted",
+      reason: delistReason,
     });
     const updated = await ref.get();
     return Response.json({ project: { ...updated.data(), id: updated.data()!.numericId } });

--- a/web/src/app/api/projects/[id]/reject/route.ts
+++ b/web/src/app/api/projects/[id]/reject/route.ts
@@ -1,4 +1,5 @@
 import { projectsCol } from "@/lib/db";
+import { notifyProjectStatusChange } from "@/lib/notifications";
 import { getAuthUser } from "@/lib/auth";
 export const dynamic = "force-dynamic";
 
@@ -18,10 +19,20 @@ export async function PUT(
 
   try {
     const body = await request.json().catch(() => ({}));
+    const previous = doc.data()!;
+    const rejectionReason = body.reason || null;
     await ref.update({
       status: "rejected",
-      rejection_reason: body.reason || null,
+      rejection_reason: rejectionReason,
       updated_at: new Date().toISOString(),
+    });
+    await notifyProjectStatusChange({
+      projectId: previous.numericId as number,
+      projectName: previous.name as string,
+      userId: previous.user_id as number,
+      fromStatus: previous.status as string,
+      toStatus: "rejected",
+      reason: rejectionReason,
     });
     const updated = await ref.get();
     return Response.json({ project: { ...updated.data(), id: updated.data()!.numericId } });

--- a/web/src/lib/db.ts
+++ b/web/src/lib/db.ts
@@ -27,6 +27,12 @@ export const financialSnapshotsCol = {
 	},
 };
 
+export const notificationsCol = {
+	get ref() {
+		return col("notifications");
+	},
+};
+
 // Auto-incrementing numeric ID
 export async function nextId(collection: string): Promise<number> {
 	const supabase = getSupabase();

--- a/web/src/lib/notifications.ts
+++ b/web/src/lib/notifications.ts
@@ -1,0 +1,57 @@
+import { notificationsCol } from "@/lib/db";
+
+type ProjectStatus = "approved" | "featured" | "rejected" | "delisted" | string;
+
+type StatusChangeNotificationInput = {
+  projectId: number;
+  projectName: string;
+  userId: number;
+  fromStatus?: ProjectStatus | null;
+  toStatus: ProjectStatus;
+  reason?: string | null;
+};
+
+const statusMessages: Record<string, string> = {
+  approved: "Your project has been approved and is now listed publicly.",
+  featured: "Your project has been featured on Stellar Wave Hub.",
+  rejected: "Your project was rejected by the review team.",
+  delisted: "Your project was delisted and is no longer visible publicly.",
+};
+
+function statusTitle(status: ProjectStatus) {
+  if (status === "featured") return "Project featured";
+  return `Project ${status}`;
+}
+
+export async function notifyProjectStatusChange({
+  projectId,
+  projectName,
+  userId,
+  fromStatus,
+  toStatus,
+  reason,
+}: StatusChangeNotificationInput) {
+  if (!userId || fromStatus === toStatus) return;
+
+  const now = new Date().toISOString();
+  const message = statusMessages[toStatus] ?? `Your project status changed to ${toStatus}.`;
+
+  const id = crypto.randomUUID();
+
+  await notificationsCol.ref.doc(id).set({
+    id,
+    user_id: userId,
+    project_id: projectId,
+    type: "project_status_changed",
+    title: statusTitle(toStatus),
+    message,
+    metadata: {
+      project_name: projectName,
+      from_status: fromStatus ?? null,
+      to_status: toStatus,
+      reason: reason || null,
+    },
+    read_at: null,
+    created_at: now,
+  });
+}


### PR DESCRIPTION
close #214 

Description
Added a notification helper notifyProjectStatusChange in web/src/lib/notifications.ts that writes a project_status_changed notification with metadata, read_at, and created_at.
Exposed a notifications collection accessor as notificationsCol in web/src/lib/db.ts and used crypto.randomUUID() for notification IDs written via notificationsCol.ref.doc(id).set(...).
Triggered notifications from the admin routes PUT /api/projects/[id]/approve, PUT /api/projects/[id]/reject, and PUT /api/projects/[id]/delist by calling notifyProjectStatusChange with the previous project data and optional reason.
Added a Supabase migration web/data/supabase/005_add_notifications.sql to create the notifications table, index, and an RLS read policy for users to fetch their own notifications.

Testing
npx tsc --noEmit was run and passed for the changes in web.
npm run lint was executed but surfaced pre-existing lint errors unrelated to this change and did not pass.
