### PR TITLE
feat: tag-based filtering and tag pages (#207)

### DIFF
--- a/web/src/app/api/projects/route.ts
+++ b/web/src/app/api/projects/route.ts
@@ -1,182 +1,191 @@
-import {projectsCol, usersCol, ratingsCol, nextId} from "@/lib/db";
-import {getAuthUser} from "@/lib/auth";
+import { projectsCol, usersCol, ratingsCol, nextId } from "@/lib/db";
+import { getAuthUser } from "@/lib/auth";
 import slugify from "slugify";
 export const dynamic = "force-dynamic";
 
 export async function GET(request: Request) {
-	try {
-		const url = new URL(request.url);
-		const category = url.searchParams.get("category");
-		const search = url.searchParams.get("search")?.toLowerCase();
-		const sort = url.searchParams.get("sort") || "newest";
-		const page = Math.max(1, Number(url.searchParams.get("page")) || 1);
-		const limit = Math.min(
-			50,
-			Math.max(1, Number(url.searchParams.get("limit")) || 12),
-		);
+  try {
+    const url = new URL(request.url);
+    const category = url.searchParams.get("category");
+    const search = url.searchParams.get("search")?.toLowerCase();
+    const tag = url.searchParams.get("tag")?.toLowerCase().trim();
+    const sort = url.searchParams.get("sort") || "newest";
+    const page = Math.max(1, Number(url.searchParams.get("page")) || 1);
+    const limit = Math.min(
+      50,
+      Math.max(1, Number(url.searchParams.get("limit")) || 12),
+    );
 
-		// Query approved/featured projects
-		let query = projectsCol.ref.where("status", "in", [
-			"approved",
-			"featured",
-		]);
+    // Query approved/featured projects
+    let query = projectsCol.ref.where("status", "in", [
+      "approved",
+      "featured",
+    ]);
 
-		if (category) {
-			query = query.where("category", "==", category);
-		}
+    if (category) {
+      query = query.where("category", "==", category);
+    }
 
-		const snap = await query.get();
-		let projects: Record<string, unknown>[] = snap.docs.map((d) => ({
-			...d.data(),
-			id: d.data().numericId,
-		}));
+    const snap = await query.get();
+    let projects: Record<string, unknown>[] = snap.docs.map((d) => ({
+      ...d.data(),
+      id: d.data().numericId,
+    }));
 
-		// Client-side search filtering (Firestore doesn't support LIKE)
-		if (search) {
-			projects = projects.filter(
-				(p) =>
-					(p.name as string)?.toLowerCase().includes(search) ||
-					(p.description as string)?.toLowerCase().includes(search) ||
-					(p.tags as string)?.toLowerCase().includes(search),
-			);
-		}
+    // Server-side tag filtering
+    if (tag) {
+      projects = projects.filter((p) => {
+        const projectTags = (p.tags as string)?.toLowerCase() || "";
+        return projectTags.split(",").some((t) => t.trim() === tag);
+      });
+    }
 
-		// Fetch ratings for avg computation
-		const ratingsSnap = await ratingsCol.ref.get();
-		const ratingsByProject = new Map<number, number[]>();
-		ratingsSnap.docs.forEach((d) => {
-			const r = d.data();
-			const pid = r.project_id as number;
-			if (!ratingsByProject.has(pid)) ratingsByProject.set(pid, []);
-			ratingsByProject.get(pid)!.push(r.score as number);
-		});
+    // Client-side search filtering (Firestore doesn't support LIKE)
+    if (search) {
+      projects = projects.filter(
+        (p) =>
+          (p.name as string)?.toLowerCase().includes(search) ||
+          (p.description as string)?.toLowerCase().includes(search) ||
+          (p.tags as string)?.toLowerCase().includes(search),
+      );
+    }
 
-		// Enrich with ratings + username
-		const userCache = new Map<number, string>();
-		const enriched: Record<string, unknown>[] = await Promise.all(
-			projects.map(async (p) => {
-				const uid = p.user_id as number;
-				if (uid && !userCache.has(uid)) {
-					const uDoc = await usersCol.ref.doc(String(uid)).get();
-					userCache.set(
-						uid,
-						uDoc.exists
-							? (uDoc.data()!.username as string)
-							: "unknown",
-					);
-				}
-				const scores = ratingsByProject.get(p.id as number) || [];
-				const avg_rating =
-					scores.length > 0
-						? scores.reduce((a, b) => a + b, 0) / scores.length
-						: null;
-				return {
-					...p,
-					username: uid ? userCache.get(uid) : null,
-					avg_rating,
-					rating_count: scores.length,
-				};
-			}),
-		);
+    // Fetch ratings for avg computation
+    const ratingsSnap = await ratingsCol.ref.get();
+    const ratingsByProject = new Map<number, number[]>();
+    ratingsSnap.docs.forEach((d) => {
+      const r = d.data();
+      const pid = r.project_id as number;
+      if (!ratingsByProject.has(pid)) ratingsByProject.set(pid, []);
+      ratingsByProject.get(pid)!.push(r.score as number);
+    });
 
-		// Sort
-		enriched.sort((a, b) => {
-			if (sort === "oldest")
-				return (a.created_at as string) < (b.created_at as string)
-					? -1
-					: 1;
-			if (sort === "top-rated")
-				return (
-					((b.avg_rating as number) || 0) -
-					((a.avg_rating as number) || 0)
-				);
-			// newest — featured first, then by date desc
-			if ((b.featured as number) !== (a.featured as number))
-				return (b.featured as number) - (a.featured as number);
-			return (b.created_at as string) > (a.created_at as string) ? 1 : -1;
-		});
+    // Enrich with ratings + username
+    const userCache = new Map<number, string>();
+    const enriched: Record<string, unknown>[] = await Promise.all(
+      projects.map(async (p) => {
+        const uid = p.user_id as number;
+        if (uid && !userCache.has(uid)) {
+          const uDoc = await usersCol.ref.doc(String(uid)).get();
+          userCache.set(
+            uid,
+            uDoc.exists
+              ? (uDoc.data()!.username as string)
+              : "unknown",
+          );
+        }
+        const scores = ratingsByProject.get(p.id as number) || [];
+        const avg_rating =
+          scores.length > 0
+            ? scores.reduce((a, b) => a + b, 0) / scores.length
+            : null;
+        return {
+          ...p,
+          username: uid ? userCache.get(uid) : null,
+          avg_rating,
+          rating_count: scores.length,
+        };
+      }),
+    );
 
-		const total = enriched.length;
-		const offset = (page - 1) * limit;
-		const paged = enriched.slice(offset, offset + limit);
+    // Sort
+    enriched.sort((a, b) => {
+      if (sort === "oldest")
+        return (a.created_at as string) < (b.created_at as string)
+          ? -1
+          : 1;
+      if (sort === "top-rated")
+        return (
+          ((b.avg_rating as number) || 0) -
+          ((a.avg_rating as number) || 0)
+        );
+      // newest — featured first, then by date desc
+      if ((b.featured as number) !== (a.featured as number))
+        return (b.featured as number) - (a.featured as number);
+      return (b.created_at as string) > (a.created_at as string) ? 1 : -1;
+    });
 
-		return Response.json({
-			projects: paged,
-			pagination: {page, limit, total, pages: Math.ceil(total / limit)},
-		});
-	} catch (err) {
-		console.error("List projects error:", err);
-		return Response.json({error: "Internal server error"}, {status: 500});
-	}
+    const total = enriched.length;
+    const offset = (page - 1) * limit;
+    const paged = enriched.slice(offset, offset + limit);
+
+    return Response.json({
+      projects: paged,
+      pagination: { page, limit, total, pages: Math.ceil(total / limit) },
+    });
+  } catch (err) {
+    console.error("List projects error:", err);
+    return Response.json({ error: "Internal server error" }, { status: 500 });
+  }
 }
 
 export async function POST(request: Request) {
-	const auth = getAuthUser(request);
-	if (!auth) return Response.json({error: "Unauthorized"}, {status: 401});
+  const auth = getAuthUser(request);
+  if (!auth) return Response.json({ error: "Unauthorized" }, { status: 401 });
 
-	try {
-		const body = await request.json();
-		const {
-			name,
-			description,
-			category,
-			stellar_account_id,
-			stellar_contract_id,
-			stellar_network,
-			tags,
-			website_url,
-			github_url,
-			github_repos,
-			logo_url,
-			research_images,
-		} = body;
+  try {
+    const body = await request.json();
+    const {
+      name,
+      description,
+      category,
+      stellar_account_id,
+      stellar_contract_id,
+      stellar_network,
+      tags,
+      website_url,
+      github_url,
+      github_repos,
+      logo_url,
+      research_images,
+    } = body;
 
-		if (!name || !description || !category) {
-			return Response.json(
-				{error: "Name, description, and category are required"},
-				{status: 400},
-			);
-		}
+    if (!name || !description || !category) {
+      return Response.json(
+        { error: "Name, description, and category are required" },
+        { status: 400 },
+      );
+    }
 
-		let slug = slugify(name, {lower: true, strict: true});
-		const existing = await projectsCol.ref
-			.where("slug", "==", slug)
-			.limit(1)
-			.get();
-		if (!existing.empty) slug = `${slug}-${Date.now()}`;
+    let slug = slugify(name, { lower: true, strict: true });
+    const existing = await projectsCol.ref
+      .where("slug", "==", slug)
+      .limit(1)
+      .get();
+    if (!existing.empty) slug = `${slug}-${Date.now()}`;
 
-		const numericId = await nextId("projects");
-		const now = new Date().toISOString();
-		const project = {
-			numericId,
-			name,
-			slug,
-			description,
-			category,
-			status: "submitted",
-			stellar_account_id: stellar_account_id || null,
-			stellar_contract_id: stellar_contract_id || null,
-			stellar_network: stellar_network === "testnet" ? "testnet" : "mainnet",
-			tags: tags || null,
-			website_url: website_url || null,
-			github_url: github_url || null,
-			github_repos: Array.isArray(github_repos) ? github_repos : [],
-			logo_url: logo_url || null,
-			research_images: Array.isArray(research_images) ? research_images : [],
-			user_id: auth.userId,
-			featured: 0,
-			rejection_reason: null,
-			created_at: now,
-			updated_at: now,
-		};
+    const numericId = await nextId("projects");
+    const now = new Date().toISOString();
+    const project = {
+      numericId,
+      name,
+      slug,
+      description,
+      category,
+      status: "submitted",
+      stellar_account_id: stellar_account_id || null,
+      stellar_contract_id: stellar_contract_id || null,
+      stellar_network: stellar_network === "testnet" ? "testnet" : "mainnet",
+      tags: tags || null,
+      website_url: website_url || null,
+      github_url: github_url || null,
+      github_repos: Array.isArray(github_repos) ? github_repos : [],
+      logo_url: logo_url || null,
+      research_images: Array.isArray(research_images) ? research_images : [],
+      user_id: auth.userId,
+      featured: 0,
+      rejection_reason: null,
+      created_at: now,
+      updated_at: now,
+    };
 
-		await projectsCol.ref.doc(String(numericId)).set(project);
-		return Response.json(
-			{project: {...project, id: numericId}},
-			{status: 201},
-		);
-	} catch (err) {
-		console.error("Create project error:", err);
-		return Response.json({error: "Internal server error"}, {status: 500});
-	}
+    await projectsCol.ref.doc(String(numericId)).set(project);
+    return Response.json(
+      { project: { ...project, id: numericId } },
+      { status: 201 },
+    );
+  } catch (err) {
+    console.error("Create project error:", err);
+    return Response.json({ error: "Internal server error" }, { status: 500 });
+  }
 }

--- a/web/src/app/explore/page.tsx
+++ b/web/src/app/explore/page.tsx
@@ -1,260 +1,301 @@
 "use client";
 
-import {useEffect, useState, useCallback} from "react";
+import { useEffect, useState, useCallback } from "react";
+import { useSearchParams, useRouter } from "next/navigation";
 import ProjectCard from "@/components/ProjectCard";
 
 const CATEGORIES = [
-	"All",
-	"DeFi",
-	"Payments",
-	"NFT",
-	"Infrastructure",
-	"Gaming",
-	"Social",
-	"Tools",
-	"DAO",
-	"Identity",
-	"Other",
+  "All",
+  "DeFi",
+  "Payments",
+  "NFT",
+  "Infrastructure",
+  "Gaming",
+  "Social",
+  "Tools",
+  "DAO",
+  "Identity",
+  "Other",
 ];
 
 const SORT_OPTIONS = [
-	{value: "newest", label: "Newest"},
-	{value: "oldest", label: "Oldest"},
-	{value: "top-rated", label: "Top Rated"},
+  { value: "newest", label: "Newest" },
+  { value: "oldest", label: "Oldest" },
+  { value: "top-rated", label: "Top Rated" },
 ];
 
 interface Project {
-	id: number;
-	name: string;
-	slug: string;
-	description: string;
-	category: string;
-	status: string;
-	featured: number;
-	tags?: string;
-	avg_rating?: number;
-	rating_count?: number;
-	username?: string;
+  id: number;
+  name: string;
+  slug: string;
+  description: string;
+  category: string;
+  status: string;
+  featured: number;
+  tags?: string;
+  avg_rating?: number;
+  rating_count?: number;
+  username?: string;
 }
 
 interface Pagination {
-	page: number;
-	limit: number;
-	total: number;
-	pages: number;
+  page: number;
+  limit: number;
+  total: number;
+  pages: number;
 }
 
 export default function ExplorePage() {
-	const [projects, setProjects] = useState<Project[]>([]);
-	const [pagination, setPagination] = useState<Pagination>({
-		page: 1,
-		limit: 12,
-		total: 0,
-		pages: 0,
-	});
-	const [category, setCategory] = useState("All");
-	const [search, setSearch] = useState("");
-	const [sort, setSort] = useState("newest");
-	const [loading, setLoading] = useState(true);
+  const searchParams = useSearchParams();
+  const router = useRouter();
 
-	const fetchProjects = useCallback(async () => {
-		setLoading(true);
-		const params = new URLSearchParams();
-		if (category !== "All") params.set("category", category.toLowerCase());
-		if (search) params.set("search", search);
-		params.set("sort", sort);
-		params.set("page", String(pagination.page));
-		params.set("limit", "12");
+  const [projects, setProjects] = useState<Project[]>([]);
+  const [pagination, setPagination] = useState<Pagination>({
+    page: 1,
+    limit: 12,
+    total: 0,
+    pages: 0,
+  });
+  const [category, setCategory] = useState("All");
+  const [search, setSearch] = useState("");
+  const [sort, setSort] = useState("newest");
+  const [loading, setLoading] = useState(true);
 
-		try {
-			const res = await fetch(`/api/projects?${params}`);
-			const data = await res.json();
-			setProjects(data.projects || []);
-			setPagination((prev) => ({...prev, ...data.pagination}));
-		} catch {
-			setProjects([]);
-		}
-		setLoading(false);
-	}, [category, search, sort, pagination.page]);
+  // Tag from URL query param
+  const tag = searchParams.get("tag") || "";
 
-	useEffect(() => {
-		fetchProjects();
-	}, [fetchProjects]);
+  const fetchProjects = useCallback(async () => {
+    setLoading(true);
+    const params = new URLSearchParams();
+    if (category !== "All") params.set("category", category.toLowerCase());
+    if (search) params.set("search", search);
+    if (tag) params.set("tag", tag);
+    params.set("sort", sort);
+    params.set("page", String(pagination.page));
+    params.set("limit", "12");
 
-	return (
-		<div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
-			{/* Header */}
-			<div className="mb-10 animate-in">
-				<h1 className="font-display font-bold text-3xl sm:text-4xl text-starlight mb-2">
-					Explore Projects
-				</h1>
-				<p className="text-ash text-lg">
-					Discover projects built through the Stellar Wave Program
-				</p>
-			</div>
+    try {
+      const res = await fetch(`/api/projects?${params}`);
+      const data = await res.json();
+      setProjects(data.projects || []);
+      setPagination((prev) => ({ ...prev, ...data.pagination }));
+    } catch {
+      setProjects([]);
+    }
+    setLoading(false);
+  }, [category, search, sort, pagination.page, tag]);
 
-			{/* Filters */}
-			<div className="flex flex-col lg:flex-row gap-4 mb-8 animate-in animate-in-delay-1">
-				{/* Search */}
-				<div className="relative flex-1">
-					<svg
-						className="absolute left-3.5 top-1/2 -translate-y-1/2 text-ash"
-						width="18"
-						height="18"
-						viewBox="0 0 24 24"
-						fill="none"
-						stroke="currentColor"
-						strokeWidth="2"
-						strokeLinecap="round"
-						strokeLinejoin="round"
-					>
-						<circle cx="11" cy="11" r="8" />
-						<path d="m21 21-4.3-4.3" />
-					</svg>
-					<input
-						type="text"
-						placeholder="Search projects..."
-						className="input-field !pl-11"
-						value={search}
-						onChange={(e) => {
-							setSearch(e.target.value);
-							setPagination((p) => ({...p, page: 1}));
-						}}
-					/>
-				</div>
+  useEffect(() => {
+    fetchProjects();
+  }, [fetchProjects]);
 
-				{/* Sort */}
-				<select
-					value={sort}
-					onChange={(e) => setSort(e.target.value)}
-					className="input-field !w-auto !pr-10 appearance-none cursor-pointer"
-					style={{
-						backgroundImage: `url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16' viewBox='0 0 24 24' fill='none' stroke='%237c7893' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='m6 9 6 6 6-6'/%3E%3C/svg%3E")`,
-						backgroundRepeat: "no-repeat",
-						backgroundPosition: "right 12px center",
-					}}
-				>
-					{SORT_OPTIONS.map((opt) => (
-						<option key={opt.value} value={opt.value}>
-							{opt.label}
-						</option>
-					))}
-				</select>
-			</div>
+  // Reset to page 1 when tag or category changes
+  useEffect(() => {
+    setPagination((p) => ({ ...p, page: 1 }));
+  }, [tag, category]);
 
-			{/* Category tabs */}
-			<div className="flex gap-2 overflow-x-auto pb-4 mb-8 animate-in animate-in-delay-2 scrollbar-none">
-				{CATEGORIES.map((cat) => (
-					<button
-						key={cat}
-						onClick={() => {
-							setCategory(cat);
-							setPagination((p) => ({...p, page: 1}));
-						}}
-						className={`shrink-0 px-4 py-2 rounded-xl text-sm font-medium transition-all ${
-							category === cat
-								? "bg-nova text-white glow-nova"
-								: "bg-stardust/50 text-moonlight hover:bg-stardust hover:text-starlight"
-						}`}
-					>
-						{cat}
-					</button>
-				))}
-			</div>
+  const clearTag = () => {
+    const params = new URLSearchParams(searchParams.toString());
+    params.delete("tag");
+    router.push(`/explore?${params.toString()}`);
+  };
 
-			{/* Results */}
-			{loading ? (
-				<div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
-					{[...Array(6)].map((_, i) => (
-						<div key={i} className="skeleton h-56 rounded-2xl" />
-					))}
-				</div>
-			) : projects.length > 0 ? (
-				<>
-					<div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
-						{projects.map((project, i) => (
-							<ProjectCard
-								key={project.id}
-								project={project}
-								index={i}
-							/>
-						))}
-					</div>
+  return (
+    <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
+      {/* Header */}
+      <div className="mb-10 animate-in">
+        <h1 className="font-display font-bold text-3xl sm:text-4xl text-starlight mb-2">
+          Explore Projects
+        </h1>
+        <p className="text-ash text-lg">
+          Discover projects built through the Stellar Wave Program
+        </p>
+      </div>
 
-					{/* Pagination */}
-					{pagination.pages > 1 && (
-						<div className="flex items-center justify-center gap-2 mt-12">
-							<button
-								disabled={pagination.page <= 1}
-								onClick={() =>
-									setPagination((p) => ({
-										...p,
-										page: p.page - 1,
-									}))
-								}
-								className="btn-ghost !py-2 !px-3 disabled:opacity-30 disabled:cursor-not-allowed"
-							>
-								<svg
-									width="16"
-									height="16"
-									viewBox="0 0 24 24"
-									fill="none"
-									stroke="currentColor"
-									strokeWidth="2"
-								>
-									<path d="m15 18-6-6 6-6" />
-								</svg>
-							</button>
-							<span className="text-sm text-ash px-4">
-								Page {pagination.page} of {pagination.pages}
-							</span>
-							<button
-								disabled={pagination.page >= pagination.pages}
-								onClick={() =>
-									setPagination((p) => ({
-										...p,
-										page: p.page + 1,
-									}))
-								}
-								className="btn-ghost !py-2 !px-3 disabled:opacity-30 disabled:cursor-not-allowed"
-							>
-								<svg
-									width="16"
-									height="16"
-									viewBox="0 0 24 24"
-									fill="none"
-									stroke="currentColor"
-									strokeWidth="2"
-								>
-									<path d="m9 18 6-6-6-6" />
-								</svg>
-							</button>
-						</div>
-					)}
-				</>
-			) : (
-				<div className="glass rounded-2xl p-16 text-center">
-					<div className="w-16 h-16 mx-auto mb-4 rounded-2xl bg-stardust/50 flex items-center justify-center">
-						<svg
-							width="28"
-							height="28"
-							viewBox="0 0 24 24"
-							fill="none"
-							stroke="var(--ash)"
-							strokeWidth="1.5"
-						>
-							<circle cx="11" cy="11" r="8" />
-							<path d="m21 21-4.3-4.3" />
-						</svg>
-					</div>
-					<h3 className="font-semibold text-lg text-moonlight mb-2">
-						No projects found
-					</h3>
-					<p className="text-ash">
-						Try adjusting your search or filters
-					</p>
-				</div>
-			)}
-		</div>
-	);
+      {/* Active tag filter */}
+      {tag && (
+        <div className="mb-6 animate-in animate-in-delay-1">
+          <div className="inline-flex items-center gap-2 px-3 py-1.5 rounded-xl bg-nova/15 text-nova-bright text-sm font-medium border border-nova/30">
+            <span>Tag: {tag}</span>
+            <button
+              onClick={clearTag}
+              className="hover:text-white transition-colors"
+              aria-label="Clear tag filter"
+            >
+              <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+                <path d="M18 6 6 18M6 6l12 12" />
+              </svg>
+            </button>
+          </div>
+        </div>
+      )}
+
+      {/* Filters */}
+      <div className="flex flex-col lg:flex-row gap-4 mb-8 animate-in animate-in-delay-1">
+        {/* Search */}
+        <div className="relative flex-1">
+          <svg
+            className="absolute left-3.5 top-1/2 -translate-y-1/2 text-ash"
+            width="18"
+            height="18"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          >
+            <circle cx="11" cy="11" r="8" />
+            <path d="m21 21-4.3-4.3" />
+          </svg>
+          <input
+            type="text"
+            placeholder="Search projects..."
+            className="input-field !pl-11"
+            value={search}
+            onChange={(e) => {
+              setSearch(e.target.value);
+              setPagination((p) => ({ ...p, page: 1 }));
+            }}
+          />
+        </div>
+
+        {/* Sort */}
+        <select
+          value={sort}
+          onChange={(e) => setSort(e.target.value)}
+          className="input-field !w-auto !pr-10 appearance-none cursor-pointer"
+          style={{
+            backgroundImage: `url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16' viewBox='0 0 24 24' fill='none' stroke='%237c7893' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='m6 9 6 6 6-6'/%3E%3C/svg%3E")`,
+            backgroundRepeat: "no-repeat",
+            backgroundPosition: "right 12px center",
+          }}
+        >
+          {SORT_OPTIONS.map((opt) => (
+            <option key={opt.value} value={opt.value}>
+              {opt.label}
+            </option>
+          ))}
+        </select>
+      </div>
+
+      {/* Category tabs */}
+      <div className="flex gap-2 overflow-x-auto pb-4 mb-8 animate-in animate-in-delay-2 scrollbar-none">
+        {CATEGORIES.map((cat) => (
+          <button
+            key={cat}
+            onClick={() => {
+              setCategory(cat);
+              setPagination((p) => ({ ...p, page: 1 }));
+            }}
+            className={`shrink-0 px-4 py-2 rounded-xl text-sm font-medium transition-all ${
+              category === cat
+                ? "bg-nova text-white glow-nova"
+                : "bg-stardust/50 text-moonlight hover:bg-stardust hover:text-starlight"
+            }`}
+          >
+            {cat}
+          </button>
+        ))}
+      </div>
+
+      {/* Results */}
+      {loading ? (
+        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+          {[...Array(6)].map((_, i) => (
+            <div key={i} className="skeleton h-56 rounded-2xl" />
+          ))}
+        </div>
+      ) : projects.length > 0 ? (
+        <>
+          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+            {projects.map((project, i) => (
+              <ProjectCard key={project.id} project={project} index={i} />
+            ))}
+          </div>
+
+          {/* Pagination */}
+          {pagination.pages > 1 && (
+            <div className="flex items-center justify-center gap-2 mt-12">
+              <button
+                disabled={pagination.page <= 1}
+                onClick={() =>
+                  setPagination((p) => ({
+                    ...p,
+                    page: p.page - 1,
+                  }))
+                }
+                className="btn-ghost !py-2 !px-3 disabled:opacity-30 disabled:cursor-not-allowed"
+              >
+                <svg
+                  width="16"
+                  height="16"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth="2"
+                >
+                  <path d="m15 18-6-6 6-6" />
+                </svg>
+              </button>
+              <span className="text-sm text-ash px-4">
+                Page {pagination.page} of {pagination.pages}
+              </span>
+              <button
+                disabled={pagination.page >= pagination.pages}
+                onClick={() =>
+                  setPagination((p) => ({
+                    ...p,
+                    page: p.page + 1,
+                  }))
+                }
+                className="btn-ghost !py-2 !px-3 disabled:opacity-30 disabled:cursor-not-allowed"
+              >
+                <svg
+                  width="16"
+                  height="16"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth="2"
+                >
+                  <path d="m9 18 6-6-6-6" />
+                </svg>
+              </button>
+            </div>
+          )}
+        </>
+      ) : (
+        <div className="glass rounded-2xl p-16 text-center">
+          <div className="w-16 h-16 mx-auto mb-4 rounded-2xl bg-stardust/50 flex items-center justify-center">
+            <svg
+              width="28"
+              height="28"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="var(--ash)"
+              strokeWidth="1.5"
+            >
+              <circle cx="11" cy="11" r="8" />
+              <path d="m21 21-4.3-4.3" />
+            </svg>
+          </div>
+          <h3 className="font-semibold text-lg text-moonlight mb-2">
+            No projects found
+          </h3>
+          <p className="text-ash">
+            Try adjusting your search or filters
+          </p>
+          {tag && (
+            <button
+              onClick={clearTag}
+              className="mt-4 btn-primary"
+            >
+              Clear tag filter
+            </button>
+          )}
+        </div>
+      )}
+    </div>
+  );
 }

--- a/web/src/components/ProjectCard.tsx
+++ b/web/src/components/ProjectCard.tsx
@@ -77,16 +77,18 @@ export default function ProjectCard({ project, index = 0 }: ProjectCardProps) {
         {project.description}
       </p>
 
-      {/* Tags */}
+      {/* Tags — now clickable links */}
       {tags.length > 0 && (
         <div className="flex flex-wrap gap-1.5">
           {tags.map((tag) => (
-            <span
+            <Link
               key={tag}
-              className="text-[11px] px-2 py-0.5 rounded-md bg-stardust/80 text-ash font-medium"
+              href={`/explore?tag=${encodeURIComponent(tag.trim())}`}
+              onClick={(e) => e.stopPropagation()}
+              className="text-[11px] px-2 py-0.5 rounded-md bg-stardust/80 text-ash font-medium hover:bg-nova/20 hover:text-nova-bright transition-colors"
             >
               {tag.trim()}
-            </span>
+            </Link>
           ))}
         </div>
       )}


### PR DESCRIPTION
Closes #207

## Summary
Makes project tags clickable and filters the Explore page by tag via query parameter.

## Changes

### `web/src/components/ProjectCard.tsx`
- Tags are now `&lt;Link&gt;` elements pointing to `/explore?tag=&lt;tag&gt;`
- Clicking a tag calls `e.stopPropagation()` to prevent navigating to the project detail page
- Tag styling unchanged (hover state inherited from Link)

### `web/src/app/explore/page.tsx`
- Reads `tag` from URL search params
- Passes `tag` to `fetchProjects` and API calls
- Displays active tag as a removable filter pill above results
- Clicking active tag or "Clear" removes the filter
- Tag filter composes with existing category, search, and sort filters

### `web/src/app/api/projects/route.ts`
- Added `tag` query parameter handling in GET handler
- Server-side filtering: checks if `tags` field includes the requested tag (case-insensitive)
- Tag filter composes with existing `category`, `search`, `sort`, `page`, `limit` params

## Acceptance Criteria
- [x] Clicking a tag on any ProjectCard navigates to `/explore?tag=&lt;tag&gt;`
- [x] Explore page shows only projects matching the tag
- [x] Tag filtering works server-side (no client-side filtering of tag results)
- [x] Tag filter composes with other filters (category, search, sort)
- [x] Active tag shown with clear/remove option