### PR TITLE
Add maintainer (sub-admin) role to the data model

### DIFF
--- a/web/data/supabase/005_add_maintainer_role.sql
+++ b/web/data/supabase/005_add_maintainer_role.sql
@@ -1,0 +1,11 @@
+-- Stellar Wave Hub - Migration 005: Add maintainer role
+-- Adds a CHECK constraint to users.role to enforce valid roles
+-- (contributor < maintainer < admin)
+
+begin;
+
+alter table if exists public.users
+  add constraint users_role_check
+  check (role in ('contributor', 'maintainer', 'admin'));
+
+commit;

--- a/web/data/supabase/rls.sql
+++ b/web/data/supabase/rls.sql
@@ -4,7 +4,7 @@
 -- NOTE:
 -- These policies assume JWT custom claims:
 --   app_user_id (numericId as string)
---   app_role    (e.g. "admin" or "contributor")
+--   app_role    (e.g. "admin", "maintainer", or "contributor")
 -- If those claims are absent, authenticated write policies will deny access.
 
 begin;
@@ -101,7 +101,7 @@ create policy projects_owner_update
     ) is not null
     and (
       user_id = (auth.jwt() ->> 'app_user_id')::bigint
-      or coalesce(auth.jwt() ->> 'app_role', '') = 'admin'
+      or coalesce(auth.jwt() ->> 'app_role', '') in ('admin', 'maintainer')
     )
   )
   with check (
@@ -110,7 +110,7 @@ create policy projects_owner_update
     ) is not null
     and (
       user_id = (auth.jwt() ->> 'app_user_id')::bigint
-      or coalesce(auth.jwt() ->> 'app_role', '') = 'admin'
+      or coalesce(auth.jwt() ->> 'app_role', '') in ('admin', 'maintainer')
     )
   );
 
@@ -124,7 +124,7 @@ create policy projects_owner_delete
     ) is not null
     and (
       user_id = (auth.jwt() ->> 'app_user_id')::bigint
-      or coalesce(auth.jwt() ->> 'app_role', '') = 'admin'
+      or coalesce(auth.jwt() ->> 'app_role', '') in ('admin', 'maintainer')
     )
   );
 
@@ -161,7 +161,7 @@ create policy ratings_owner_update
     ) is not null
     and (
       user_id = (auth.jwt() ->> 'app_user_id')::bigint
-      or coalesce(auth.jwt() ->> 'app_role', '') = 'admin'
+      or coalesce(auth.jwt() ->> 'app_role', '') in ('admin', 'maintainer')
     )
   )
   with check (
@@ -170,7 +170,7 @@ create policy ratings_owner_update
     ) is not null
     and (
       user_id = (auth.jwt() ->> 'app_user_id')::bigint
-      or coalesce(auth.jwt() ->> 'app_role', '') = 'admin'
+      or coalesce(auth.jwt() ->> 'app_role', '') in ('admin', 'maintainer')
     )
   );
 
@@ -184,7 +184,7 @@ create policy ratings_owner_delete
     ) is not null
     and (
       user_id = (auth.jwt() ->> 'app_user_id')::bigint
-      or coalesce(auth.jwt() ->> 'app_role', '') = 'admin'
+      or coalesce(auth.jwt() ->> 'app_role', '') in ('admin', 'maintainer')
     )
   );
 

--- a/web/data/supabase/schema.sql
+++ b/web/data/supabase/schema.sql
@@ -8,7 +8,7 @@ create table if not exists public.users (
   username text not null,
   email text,
   password_hash text,
-  role text not null default 'contributor',
+  role text not null default 'contributor' check (role in ('contributor', 'maintainer', 'admin')),
   stellar_address text,
   github_url text,
   twitter_url text,

--- a/web/src/app/admin/page.tsx
+++ b/web/src/app/admin/page.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useEffect, useCallback } from "react";
 import { useAuth } from "@/context/AuthContext";
+import { hasMinRole } from "@/lib/roles";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import Link from "next/link";
 import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/components/ui/tabs";
@@ -937,7 +938,7 @@ export default function AdminPage() {
   const filteredFeatured = filterProjects(featured, search);
   const filteredAll = filterProjects(all, search);
 
-  if (!user || user.role !== "admin") {
+  if (!user || !hasMinRole(user.role, "admin")) {
     return (
       <div className="min-h-[60vh] flex items-center justify-center px-4">
         <div className="glass rounded-2xl p-12 text-center max-w-md">

--- a/web/src/app/api/admin/projects/route.ts
+++ b/web/src/app/api/admin/projects/route.ts
@@ -1,10 +1,10 @@
 import { projectsCol, usersCol, ratingsCol } from "@/lib/db";
-import { getAuthUser } from "@/lib/auth";
+import { getAuthUser, hasMinRole } from "@/lib/auth";
 export const dynamic = "force-dynamic";
 
 export async function GET(request: Request) {
   const auth = getAuthUser(request);
-  if (!auth || auth.role !== "admin") {
+  if (!auth || !hasMinRole(auth.role, "admin")) {
     return Response.json({ error: "Forbidden" }, { status: 403 });
   }
 

--- a/web/src/app/api/projects/[id]/approve/route.ts
+++ b/web/src/app/api/projects/[id]/approve/route.ts
@@ -1,5 +1,5 @@
 import { projectsCol } from "@/lib/db";
-import { getAuthUser } from "@/lib/auth";
+import { getAuthUser, hasMinRole } from "@/lib/auth";
 export const dynamic = "force-dynamic";
 
 export async function PUT(
@@ -7,7 +7,7 @@ export async function PUT(
   { params }: { params: Promise<{ id: string }> }
 ) {
   const auth = getAuthUser(request);
-  if (!auth || auth.role !== "admin") {
+  if (!auth || !hasMinRole(auth.role, "admin")) {
     return Response.json({ error: "Forbidden" }, { status: 403 });
   }
 

--- a/web/src/app/api/projects/[id]/delete/route.ts
+++ b/web/src/app/api/projects/[id]/delete/route.ts
@@ -1,5 +1,5 @@
 import { projectsCol, ratingsCol } from "@/lib/db";
-import { getAuthUser } from "@/lib/auth";
+import { getAuthUser, hasMinRole } from "@/lib/auth";
 export const dynamic = "force-dynamic";
 
 export async function DELETE(
@@ -7,7 +7,7 @@ export async function DELETE(
   { params }: { params: Promise<{ id: string }> }
 ) {
   const auth = getAuthUser(request);
-  if (!auth || auth.role !== "admin") {
+  if (!auth || !hasMinRole(auth.role, "admin")) {
     return Response.json({ error: "Forbidden" }, { status: 403 });
   }
 

--- a/web/src/app/api/projects/[id]/delist/route.ts
+++ b/web/src/app/api/projects/[id]/delist/route.ts
@@ -1,5 +1,5 @@
 import { projectsCol } from "@/lib/db";
-import { getAuthUser } from "@/lib/auth";
+import { getAuthUser, hasMinRole } from "@/lib/auth";
 export const dynamic = "force-dynamic";
 
 export async function PUT(
@@ -7,7 +7,7 @@ export async function PUT(
   { params }: { params: Promise<{ id: string }> }
 ) {
   const auth = getAuthUser(request);
-  if (!auth || auth.role !== "admin") {
+  if (!auth || !hasMinRole(auth.role, "admin")) {
     return Response.json({ error: "Forbidden" }, { status: 403 });
   }
 

--- a/web/src/app/api/projects/[id]/edit/route.ts
+++ b/web/src/app/api/projects/[id]/edit/route.ts
@@ -1,5 +1,5 @@
 import { projectsCol } from "@/lib/db";
-import { getAuthUser } from "@/lib/auth";
+import { getAuthUser, hasMinRole } from "@/lib/auth";
 export const dynamic = "force-dynamic";
 
 export async function PUT(
@@ -15,7 +15,7 @@ export async function PUT(
   if (!doc.exists) return Response.json({ error: "Project not found" }, { status: 404 });
 
   const project = doc.data()!;
-  if (project.user_id !== auth.userId && auth.role !== "admin") {
+  if (project.user_id !== auth.userId && !hasMinRole(auth.role, "admin")) {
     return Response.json({ error: "Forbidden" }, { status: 403 });
   }
 

--- a/web/src/app/api/projects/[id]/reject/route.ts
+++ b/web/src/app/api/projects/[id]/reject/route.ts
@@ -1,5 +1,5 @@
 import { projectsCol } from "@/lib/db";
-import { getAuthUser } from "@/lib/auth";
+import { getAuthUser, hasMinRole } from "@/lib/auth";
 export const dynamic = "force-dynamic";
 
 export async function PUT(
@@ -7,7 +7,7 @@ export async function PUT(
   { params }: { params: Promise<{ id: string }> }
 ) {
   const auth = getAuthUser(request);
-  if (!auth || auth.role !== "admin") {
+  if (!auth || !hasMinRole(auth.role, "admin")) {
     return Response.json({ error: "Forbidden" }, { status: 403 });
   }
 

--- a/web/src/app/api/projects/pending/route.ts
+++ b/web/src/app/api/projects/pending/route.ts
@@ -1,10 +1,10 @@
 import { projectsCol, usersCol } from "@/lib/db";
-import { getAuthUser } from "@/lib/auth";
+import { getAuthUser, hasMinRole } from "@/lib/auth";
 export const dynamic = "force-dynamic";
 
 export async function GET(request: Request) {
   const auth = getAuthUser(request);
-  if (!auth || auth.role !== "admin") {
+  if (!auth || !hasMinRole(auth.role, "admin")) {
     return Response.json({ error: "Forbidden" }, { status: 403 });
   }
 

--- a/web/src/app/api/ratings/[id]/route.ts
+++ b/web/src/app/api/ratings/[id]/route.ts
@@ -1,5 +1,5 @@
 import { ratingsCol } from "@/lib/db";
-import { getAuthUser } from "@/lib/auth";
+import { getAuthUser, hasMinRole } from "@/lib/auth";
 export const dynamic = "force-dynamic";
 
 export async function DELETE(
@@ -15,7 +15,7 @@ export async function DELETE(
   if (!doc.exists) return Response.json({ error: "Rating not found" }, { status: 404 });
 
   const rating = doc.data()!;
-  if (rating.user_id !== auth.userId && auth.role !== "admin") {
+  if (rating.user_id !== auth.userId && !hasMinRole(auth.role, "admin")) {
     return Response.json({ error: "Forbidden" }, { status: 403 });
   }
 

--- a/web/src/components/Navbar.tsx
+++ b/web/src/components/Navbar.tsx
@@ -3,6 +3,7 @@
 import Link from "next/link";
 import Image from "next/image";
 import {useAuth} from "@/context/AuthContext";
+import {hasMinRole} from "@/lib/roles";
 import {useState} from "react";
 
 export default function Navbar() {
@@ -62,7 +63,7 @@ export default function Navbar() {
 								>
 									My Projects
 								</Link>
-								{user.role === "admin" && (
+								{hasMinRole(user.role, "admin") && (
 									<Link
 										href="/admin"
 										className="px-4 py-2 rounded-lg text-sm font-medium text-solar hover:text-solar-bright hover:bg-solar/10 transition-all"
@@ -194,7 +195,7 @@ export default function Navbar() {
 							>
 								My Projects
 							</Link>
-							{user.role === "admin" && (
+							{hasMinRole(user.role, "admin") && (
 								<Link
 									href="/admin"
 									className="block px-4 py-2.5 rounded-lg text-sm font-medium text-solar hover:text-solar-bright hover:bg-solar/10"

--- a/web/src/lib/auth.ts
+++ b/web/src/lib/auth.ts
@@ -1,7 +1,10 @@
 import bcrypt from "bcryptjs";
 import jwt from "jsonwebtoken";
+import { ROLES, hasMinRole } from "./roles";
 
 const JWT_SECRET = process.env.JWT_SECRET || "stellar-wave-hub-dev-secret";
+
+export { ROLES, hasMinRole };
 
 export async function hashPassword(password: string): Promise<string> {
   return bcrypt.hash(password, 12);

--- a/web/src/lib/roles.ts
+++ b/web/src/lib/roles.ts
@@ -1,0 +1,13 @@
+export const ROLES = {
+  contributor: 0,
+  maintainer: 1,
+  admin: 2,
+} as const;
+
+export type Role = keyof typeof ROLES;
+
+export function hasMinRole(userRole: string, minRole: string): boolean {
+  const userLevel = ROLES[userRole as keyof typeof ROLES] ?? -1;
+  const minLevel = ROLES[minRole as keyof typeof ROLES] ?? -1;
+  return userLevel >= minLevel;
+}


### PR DESCRIPTION
## Overview
This PR adds a `maintainer` role (a "sub-admin" between contributor and admin) to the data model. It is the foundational issue for the whole maintainer epic.

## Related Issue
Closes #234

## Changes

### 📦 Migration
- **[ADD]** `web/data/supabase/005_add_maintainer_role.sql`
  - Adds CHECK constraint to `users.role` enforcing valid values: `contributor`, `maintainer`, `admin`

### ⚙️ Role Infrastructure
- **[ADD]** `web/src/lib/roles.ts`
  - Defines `ROLES` constants with ordering (`contributor < maintainer < admin`)
  - Exports `hasMinRole()` helper for hierarchical role checks
  - Exports `Role` type
- **[MODIFY]** `web/src/lib/auth.ts`
  - Imports and re-exports `ROLES` and `hasMinRole` for server-side use

### 🔒 Authorization Updates
- **[MODIFY]** All 8 API route files with admin checks
  - Replaced `auth.role !== "admin"` with `!hasMinRole(auth.role, "admin")`
- **[MODIFY]** `web/src/app/admin/page.tsx`
  - Admin page guard now uses `hasMinRole(user.role, "admin")`
- **[MODIFY]** `web/src/components/Navbar.tsx`
  - Admin nav link visibility now uses `hasMinRole(user.role, "admin")`

### 🛡️ Row Level Security
- **[MODIFY]** `web/data/supabase/rls.sql`
  - All admin-level RLS policies now accept `maintainer` alongside `admin` via `in ('admin', 'maintainer')`

### 📐 Schema
- **[MODIFY]** `web/data/supabase/schema.sql`
  - Added inline CHECK constraint to `users.role` column

## Verification Results

| Acceptance Criteria | Status |
|---|---|
| A user can have role `maintainer` | ✅ |
| Role is present in the JWT | ✅ |
| Role is readable via `getAuthUser` | ✅ |
| Role ordering defined (`contributor < maintainer < admin`) | ✅ |
| Migration allows role value `maintainer` | ✅ |
```
npm run lint ✅ completed (existing repo warnings only)
npm run typecheck ✅ passed
npm test -- src/config/__tests__/config.test.ts --runInBand ✅ passed (9/9)
npm run build ✅ passed
```