### PR TITLE
feat(#201): add live financial sparkline to project cards

### DIFF
--- a/web/src/app/api/financials/[projectId]/snapshots/route.ts
+++ b/web/src/app/api/financials/[projectId]/snapshots/route.ts
@@ -1,0 +1,65 @@
+import { getSupabase } from "@/lib/firebase";
+
+export const dynamic = "force-dynamic";
+
+/** Shape stored inside snapshot_data by the cron job */
+interface SnapshotData {
+  balances?: Array<{
+    asset_type: string;
+    asset_code?: string;
+    balance: string;
+  }>;
+}
+
+/** Extracts the native XLM balance from a snapshot_data record */
+function xlmBalance(snapshotData: SnapshotData): number {
+  const xlm = (snapshotData.balances ?? []).find(
+    (b) => b.asset_type === "native",
+  );
+  return xlm ? parseFloat(xlm.balance) : 0;
+}
+
+/**
+ * GET /api/financials/[projectId]/snapshots
+ *
+ * Returns up to 30 daily snapshots for the given numeric project id,
+ * oldest first — ready to feed straight into the Sparkline component.
+ *
+ * Response:
+ *   { snapshots: Array<{ created_at: string; xlm_balance: number }> }
+ */
+export async function GET(
+  _request: Request,
+  { params }: { params: Promise<{ projectId: string }> },
+) {
+  const { projectId } = await params;
+  const numericId = Number(projectId);
+
+  if (!Number.isInteger(numericId) || numericId <= 0) {
+    return Response.json({ error: "Invalid project id" }, { status: 400 });
+  }
+
+  const supabase = getSupabase();
+
+  const { data, error } = await supabase
+    .from("financial_snapshots")
+    .select("created_at, snapshot_data")
+    .eq("project_id", numericId)
+    .order("created_at", { ascending: true })
+    .limit(30);
+
+  if (error) {
+    console.error("Snapshots fetch error:", error);
+    return Response.json(
+      { error: "Failed to fetch snapshots" },
+      { status: 500 },
+    );
+  }
+
+  const snapshots = (data ?? []).map((row) => ({
+    created_at: row.created_at as string,
+    xlm_balance: xlmBalance(row.snapshot_data as SnapshotData),
+  }));
+
+  return Response.json({ snapshots });
+}

--- a/web/src/app/explore/page.tsx
+++ b/web/src/app/explore/page.tsx
@@ -1,260 +1,290 @@
 "use client";
 
-import {useEffect, useState, useCallback} from "react";
-import ProjectCard from "@/components/ProjectCard";
+import { useEffect, useState } from "react";
+import ProjectCard, { type Snapshot } from "@/components/ProjectCard";
 
 const CATEGORIES = [
-	"All",
-	"DeFi",
-	"Payments",
-	"NFT",
-	"Infrastructure",
-	"Gaming",
-	"Social",
-	"Tools",
-	"DAO",
-	"Identity",
-	"Other",
+  "All",
+  "DeFi",
+  "Payments",
+  "NFT",
+  "Infrastructure",
+  "Gaming",
+  "Social",
+  "Tools",
+  "DAO",
+  "Identity",
+  "Other",
 ];
 
 const SORT_OPTIONS = [
-	{value: "newest", label: "Newest"},
-	{value: "oldest", label: "Oldest"},
-	{value: "top-rated", label: "Top Rated"},
+  { value: "newest", label: "Newest" },
+  { value: "oldest", label: "Oldest" },
+  { value: "top-rated", label: "Top Rated" },
 ];
 
 interface Project {
-	id: number;
-	name: string;
-	slug: string;
-	description: string;
-	category: string;
-	status: string;
-	featured: number;
-	tags?: string;
-	avg_rating?: number;
-	rating_count?: number;
-	username?: string;
+  id: number;
+  name: string;
+  slug: string;
+  description: string;
+  category: string;
+  status: string;
+  featured: number;
+  tags?: string;
+  avg_rating?: number;
+  rating_count?: number;
+  username?: string;
 }
 
 interface Pagination {
-	page: number;
-	limit: number;
-	total: number;
-	pages: number;
+  page: number;
+  limit: number;
+  total: number;
+  pages: number;
 }
 
 export default function ExplorePage() {
-	const [projects, setProjects] = useState<Project[]>([]);
-	const [pagination, setPagination] = useState<Pagination>({
-		page: 1,
-		limit: 12,
-		total: 0,
-		pages: 0,
-	});
-	const [category, setCategory] = useState("All");
-	const [search, setSearch] = useState("");
-	const [sort, setSort] = useState("newest");
-	const [loading, setLoading] = useState(true);
+  const [projects, setProjects] = useState<Project[]>([]);
+  const [snapshotMap, setSnapshotMap] = useState<Record<number, Snapshot[]>>(
+    {},
+  );
+  const [pagination, setPagination] = useState<Pagination>({
+    page: 1,
+    limit: 12,
+    total: 0,
+    pages: 0,
+  });
+  const [category, setCategory] = useState("All");
+  const [search, setSearch] = useState("");
+  const [sort, setSort] = useState("newest");
+  const [loading, setLoading] = useState(true);
 
-	const fetchProjects = useCallback(async () => {
-		setLoading(true);
-		const params = new URLSearchParams();
-		if (category !== "All") params.set("category", category.toLowerCase());
-		if (search) params.set("search", search);
-		params.set("sort", sort);
-		params.set("page", String(pagination.page));
-		params.set("limit", "12");
+  useEffect(() => {
+    let cancelled = false;
 
-		try {
-			const res = await fetch(`/api/projects?${params}`);
-			const data = await res.json();
-			setProjects(data.projects || []);
-			setPagination((prev) => ({...prev, ...data.pagination}));
-		} catch {
-			setProjects([]);
-		}
-		setLoading(false);
-	}, [category, search, sort, pagination.page]);
+    async function load() {
+      setLoading(true);
+      const params = new URLSearchParams();
+      if (category !== "All") params.set("category", category.toLowerCase());
+      if (search) params.set("search", search);
+      params.set("sort", sort);
+      params.set("page", String(pagination.page));
+      params.set("limit", "12");
 
-	useEffect(() => {
-		fetchProjects();
-	}, [fetchProjects]);
+      try {
+        const res = await fetch(`/api/projects?${params}`);
+        const data = await res.json();
+        const loaded: Project[] = data.projects || [];
 
-	return (
-		<div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
-			{/* Header */}
-			<div className="mb-10 animate-in">
-				<h1 className="font-display font-bold text-3xl sm:text-4xl text-starlight mb-2">
-					Explore Projects
-				</h1>
-				<p className="text-ash text-lg">
-					Discover projects built through the Stellar Wave Program
-				</p>
-			</div>
+        if (cancelled) return;
+        setProjects(loaded);
+        setPagination((prev) => ({ ...prev, ...data.pagination }));
 
-			{/* Filters */}
-			<div className="flex flex-col lg:flex-row gap-4 mb-8 animate-in animate-in-delay-1">
-				{/* Search */}
-				<div className="relative flex-1">
-					<svg
-						className="absolute left-3.5 top-1/2 -translate-y-1/2 text-ash"
-						width="18"
-						height="18"
-						viewBox="0 0 24 24"
-						fill="none"
-						stroke="currentColor"
-						strokeWidth="2"
-						strokeLinecap="round"
-						strokeLinejoin="round"
-					>
-						<circle cx="11" cy="11" r="8" />
-						<path d="m21 21-4.3-4.3" />
-					</svg>
-					<input
-						type="text"
-						placeholder="Search projects..."
-						className="input-field !pl-11"
-						value={search}
-						onChange={(e) => {
-							setSearch(e.target.value);
-							setPagination((p) => ({...p, page: 1}));
-						}}
-					/>
-				</div>
+        // Fetch snapshots for every project in parallel — failures are swallowed.
+        const results = await Promise.allSettled(
+          loaded.map((p) =>
+            fetch(`/api/financials/${p.id}/snapshots`).then((r) => r.json()),
+          ),
+        );
 
-				{/* Sort */}
-				<select
-					value={sort}
-					onChange={(e) => setSort(e.target.value)}
-					className="input-field !w-auto !pr-10 appearance-none cursor-pointer"
-					style={{
-						backgroundImage: `url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16' viewBox='0 0 24 24' fill='none' stroke='%237c7893' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='m6 9 6 6 6-6'/%3E%3C/svg%3E")`,
-						backgroundRepeat: "no-repeat",
-						backgroundPosition: "right 12px center",
-					}}
-				>
-					{SORT_OPTIONS.map((opt) => (
-						<option key={opt.value} value={opt.value}>
-							{opt.label}
-						</option>
-					))}
-				</select>
-			</div>
+        if (cancelled) return;
+        const map: Record<number, Snapshot[]> = {};
+        results.forEach((result, i) => {
+          if (
+            result.status === "fulfilled" &&
+            Array.isArray(result.value?.snapshots)
+          ) {
+            map[loaded[i].id] = result.value.snapshots as Snapshot[];
+          }
+        });
+        setSnapshotMap(map);
+      } catch {
+        if (!cancelled) setProjects([]);
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    }
 
-			{/* Category tabs */}
-			<div className="flex gap-2 overflow-x-auto pb-4 mb-8 animate-in animate-in-delay-2 scrollbar-none">
-				{CATEGORIES.map((cat) => (
-					<button
-						key={cat}
-						onClick={() => {
-							setCategory(cat);
-							setPagination((p) => ({...p, page: 1}));
-						}}
-						className={`shrink-0 px-4 py-2 rounded-xl text-sm font-medium transition-all ${
-							category === cat
-								? "bg-nova text-white glow-nova"
-								: "bg-stardust/50 text-moonlight hover:bg-stardust hover:text-starlight"
-						}`}
-					>
-						{cat}
-					</button>
-				))}
-			</div>
+    load();
+    return () => {
+      cancelled = true;
+    };
+  }, [category, search, sort, pagination.page]);
 
-			{/* Results */}
-			{loading ? (
-				<div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
-					{[...Array(6)].map((_, i) => (
-						<div key={i} className="skeleton h-56 rounded-2xl" />
-					))}
-				</div>
-			) : projects.length > 0 ? (
-				<>
-					<div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
-						{projects.map((project, i) => (
-							<ProjectCard
-								key={project.id}
-								project={project}
-								index={i}
-							/>
-						))}
-					</div>
+  return (
+    <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
+      {/* Header */}
+      <div className="mb-10 animate-in">
+        <h1 className="font-display font-bold text-3xl sm:text-4xl text-starlight mb-2">
+          Explore Projects
+        </h1>
+        <p className="text-ash text-lg">
+          Discover projects built through the Stellar Wave Program
+        </p>
+      </div>
 
-					{/* Pagination */}
-					{pagination.pages > 1 && (
-						<div className="flex items-center justify-center gap-2 mt-12">
-							<button
-								disabled={pagination.page <= 1}
-								onClick={() =>
-									setPagination((p) => ({
-										...p,
-										page: p.page - 1,
-									}))
-								}
-								className="btn-ghost !py-2 !px-3 disabled:opacity-30 disabled:cursor-not-allowed"
-							>
-								<svg
-									width="16"
-									height="16"
-									viewBox="0 0 24 24"
-									fill="none"
-									stroke="currentColor"
-									strokeWidth="2"
-								>
-									<path d="m15 18-6-6 6-6" />
-								</svg>
-							</button>
-							<span className="text-sm text-ash px-4">
-								Page {pagination.page} of {pagination.pages}
-							</span>
-							<button
-								disabled={pagination.page >= pagination.pages}
-								onClick={() =>
-									setPagination((p) => ({
-										...p,
-										page: p.page + 1,
-									}))
-								}
-								className="btn-ghost !py-2 !px-3 disabled:opacity-30 disabled:cursor-not-allowed"
-							>
-								<svg
-									width="16"
-									height="16"
-									viewBox="0 0 24 24"
-									fill="none"
-									stroke="currentColor"
-									strokeWidth="2"
-								>
-									<path d="m9 18 6-6-6-6" />
-								</svg>
-							</button>
-						</div>
-					)}
-				</>
-			) : (
-				<div className="glass rounded-2xl p-16 text-center">
-					<div className="w-16 h-16 mx-auto mb-4 rounded-2xl bg-stardust/50 flex items-center justify-center">
-						<svg
-							width="28"
-							height="28"
-							viewBox="0 0 24 24"
-							fill="none"
-							stroke="var(--ash)"
-							strokeWidth="1.5"
-						>
-							<circle cx="11" cy="11" r="8" />
-							<path d="m21 21-4.3-4.3" />
-						</svg>
-					</div>
-					<h3 className="font-semibold text-lg text-moonlight mb-2">
-						No projects found
-					</h3>
-					<p className="text-ash">
-						Try adjusting your search or filters
-					</p>
-				</div>
-			)}
-		</div>
-	);
+      {/* Filters */}
+      <div className="flex flex-col lg:flex-row gap-4 mb-8 animate-in animate-in-delay-1">
+        {/* Search */}
+        <div className="relative flex-1">
+          <svg
+            className="absolute left-3.5 top-1/2 -translate-y-1/2 text-ash"
+            width="18"
+            height="18"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          >
+            <circle cx="11" cy="11" r="8" />
+            <path d="m21 21-4.3-4.3" />
+          </svg>
+          <input
+            type="text"
+            placeholder="Search projects..."
+            className="input-field !pl-11"
+            value={search}
+            onChange={(e) => {
+              setSearch(e.target.value);
+              setPagination((p) => ({ ...p, page: 1 }));
+            }}
+          />
+        </div>
+
+        {/* Sort */}
+        <select
+          value={sort}
+          onChange={(e) => setSort(e.target.value)}
+          className="input-field !w-auto !pr-10 appearance-none cursor-pointer"
+          style={{
+            backgroundImage: `url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16' viewBox='0 0 24 24' fill='none' stroke='%237c7893' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='m6 9 6 6 6-6'/%3E%3C/svg%3E")`,
+            backgroundRepeat: "no-repeat",
+            backgroundPosition: "right 12px center",
+          }}
+        >
+          {SORT_OPTIONS.map((opt) => (
+            <option key={opt.value} value={opt.value}>
+              {opt.label}
+            </option>
+          ))}
+        </select>
+      </div>
+
+      {/* Category tabs */}
+      <div className="flex gap-2 overflow-x-auto pb-4 mb-8 animate-in animate-in-delay-2 scrollbar-none">
+        {CATEGORIES.map((cat) => (
+          <button
+            key={cat}
+            onClick={() => {
+              setCategory(cat);
+              setPagination((p) => ({ ...p, page: 1 }));
+            }}
+            className={`shrink-0 px-4 py-2 rounded-xl text-sm font-medium transition-all ${
+              category === cat
+                ? "bg-nova text-white glow-nova"
+                : "bg-stardust/50 text-moonlight hover:bg-stardust hover:text-starlight"
+            }`}
+          >
+            {cat}
+          </button>
+        ))}
+      </div>
+
+      {/* Results */}
+      {loading ? (
+        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+          {[...Array(6)].map((_, i) => (
+            <div key={i} className="skeleton h-56 rounded-2xl" />
+          ))}
+        </div>
+      ) : projects.length > 0 ? (
+        <>
+          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+            {projects.map((project, i) => (
+              <ProjectCard
+                key={project.id}
+                project={project}
+                snapshots={snapshotMap[project.id]}
+                index={i}
+              />
+            ))}
+          </div>
+
+          {/* Pagination */}
+          {pagination.pages > 1 && (
+            <div className="flex items-center justify-center gap-2 mt-12">
+              <button
+                disabled={pagination.page <= 1}
+                onClick={() =>
+                  setPagination((p) => ({
+                    ...p,
+                    page: p.page - 1,
+                  }))
+                }
+                className="btn-ghost !py-2 !px-3 disabled:opacity-30 disabled:cursor-not-allowed"
+              >
+                <svg
+                  width="16"
+                  height="16"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth="2"
+                >
+                  <path d="m15 18-6-6 6-6" />
+                </svg>
+              </button>
+              <span className="text-sm text-ash px-4">
+                Page {pagination.page} of {pagination.pages}
+              </span>
+              <button
+                disabled={pagination.page >= pagination.pages}
+                onClick={() =>
+                  setPagination((p) => ({
+                    ...p,
+                    page: p.page + 1,
+                  }))
+                }
+                className="btn-ghost !py-2 !px-3 disabled:opacity-30 disabled:cursor-not-allowed"
+              >
+                <svg
+                  width="16"
+                  height="16"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth="2"
+                >
+                  <path d="m9 18 6-6-6-6" />
+                </svg>
+              </button>
+            </div>
+          )}
+        </>
+      ) : (
+        <div className="glass rounded-2xl p-16 text-center">
+          <div className="w-16 h-16 mx-auto mb-4 rounded-2xl bg-stardust/50 flex items-center justify-center">
+            <svg
+              width="28"
+              height="28"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="var(--ash)"
+              strokeWidth="1.5"
+            >
+              <circle cx="11" cy="11" r="8" />
+              <path d="m21 21-4.3-4.3" />
+            </svg>
+          </div>
+          <h3 className="font-semibold text-lg text-moonlight mb-2">
+            No projects found
+          </h3>
+          <p className="text-ash">Try adjusting your search or filters</p>
+        </div>
+      )}
+    </div>
+  );
 }

--- a/web/src/app/page.tsx
+++ b/web/src/app/page.tsx
@@ -2,7 +2,7 @@
 
 import Link from "next/link";
 import {useEffect, useState} from "react";
-import ProjectCard from "@/components/ProjectCard";
+import ProjectCard, {type Snapshot} from "@/components/ProjectCard";
 
 interface Project {
 	id: number;
@@ -20,12 +20,34 @@ interface Project {
 
 export default function Home() {
 	const [featured, setFeatured] = useState<Project[]>([]);
+	const [snapshotMap, setSnapshotMap] = useState<Record<number, Snapshot[]>>({});
 	const [loading, setLoading] = useState(true);
 
 	useEffect(() => {
 		fetch("/api/projects?limit=6&sort=top-rated")
 			.then((r) => r.json())
-			.then((data) => setFeatured(data.projects || []))
+			.then(async (data) => {
+				const projects: Project[] = data.projects || [];
+				setFeatured(projects);
+
+				// Fetch snapshots for each project in parallel; failures are swallowed.
+				const results = await Promise.allSettled(
+					projects.map((p) =>
+						fetch(`/api/financials/${p.id}/snapshots`).then((r) => r.json()),
+					),
+				);
+
+				const map: Record<number, Snapshot[]> = {};
+				results.forEach((result, i) => {
+					if (
+						result.status === "fulfilled" &&
+						Array.isArray(result.value?.snapshots)
+					) {
+						map[projects[i].id] = result.value.snapshots as Snapshot[];
+					}
+				});
+				setSnapshotMap(map);
+			})
 			.catch(() => {})
 			.finally(() => setLoading(false));
 	}, []);
@@ -190,6 +212,7 @@ export default function Home() {
 								<ProjectCard
 									key={project.id}
 									project={project}
+									snapshots={snapshotMap[project.id]}
 									index={i}
 								/>
 							))}

--- a/web/src/components/ProjectCard.tsx
+++ b/web/src/components/ProjectCard.tsx
@@ -1,6 +1,12 @@
 "use client";
 
 import Link from "next/link";
+import Sparkline from "@/components/Sparkline";
+
+export interface Snapshot {
+  created_at: string;
+  xlm_balance: number;
+}
 
 interface ProjectCardProps {
   project: {
@@ -17,6 +23,8 @@ interface ProjectCardProps {
     username?: string;
     logo_url?: string;
   };
+  /** Optional balance-over-time snapshots for the sparkline. */
+  snapshots?: Snapshot[];
   index?: number;
 }
 
@@ -33,9 +41,16 @@ const categoryColors: Record<string, string> = {
   other: "tag-nova",
 };
 
-export default function ProjectCard({ project, index = 0 }: ProjectCardProps) {
-  const colorClass = categoryColors[project.category?.toLowerCase()] || "tag-nova";
+export default function ProjectCard({
+  project,
+  snapshots,
+  index = 0,
+}: ProjectCardProps) {
+  const colorClass =
+    categoryColors[project.category?.toLowerCase()] || "tag-nova";
   const tags = project.tags ? project.tags.split(",").slice(0, 3) : [];
+  const sparkValues = snapshots?.map((s) => s.xlm_balance) ?? [];
+  const hasSparkline = sparkValues.length >= 2;
 
   return (
     <Link
@@ -94,28 +109,37 @@ export default function ProjectCard({ project, index = 0 }: ProjectCardProps) {
       {/* Footer */}
       <div className="flex items-center justify-between pt-2 border-t border-dust/20">
         <span className={`tag ${colorClass}`}>{project.category}</span>
-        <div className="flex items-center gap-1.5">
-          {project.avg_rating ? (
-            <>
-              <svg
-                width="14"
-                height="14"
-                viewBox="0 0 24 24"
-                fill="var(--solar)"
-                stroke="none"
-              >
-                <polygon points="12 2 15.09 8.26 22 9.27 17 14.14 18.18 21.02 12 17.77 5.82 21.02 7 14.14 2 9.27 8.91 8.26 12 2" />
-              </svg>
-              <span className="text-sm font-semibold text-solar-bright">
-                {Number(project.avg_rating).toFixed(1)}
-              </span>
-              <span className="text-xs text-ash">
-                ({project.rating_count})
-              </span>
-            </>
-          ) : (
-            <span className="text-xs text-ash">No ratings yet</span>
+
+        <div className="flex items-center gap-3">
+          {/* Sparkline — only renders when ≥2 snapshots exist */}
+          {hasSparkline && (
+            <Sparkline values={sparkValues} width={64} height={24} />
           )}
+
+          {/* Rating */}
+          <div className="flex items-center gap-1.5">
+            {project.avg_rating ? (
+              <>
+                <svg
+                  width="14"
+                  height="14"
+                  viewBox="0 0 24 24"
+                  fill="var(--solar)"
+                  stroke="none"
+                >
+                  <polygon points="12 2 15.09 8.26 22 9.27 17 14.14 18.18 21.02 12 17.77 5.82 21.02 7 14.14 2 9.27 8.91 8.26 12 2" />
+                </svg>
+                <span className="text-sm font-semibold text-solar-bright">
+                  {Number(project.avg_rating).toFixed(1)}
+                </span>
+                <span className="text-xs text-ash">
+                  ({project.rating_count})
+                </span>
+              </>
+            ) : (
+              <span className="text-xs text-ash">No ratings yet</span>
+            )}
+          </div>
         </div>
       </div>
     </Link>

--- a/web/src/components/Sparkline.tsx
+++ b/web/src/components/Sparkline.tsx
@@ -1,0 +1,107 @@
+/**
+ * Sparkline — a lightweight SVG sparkline with no external dependencies.
+ *
+ * Props:
+ *   values   — array of numbers to plot (needs ≥2 points to draw a line)
+ *   width    — SVG width  (default 80)
+ *   height   — SVG height (default 28)
+ *   className — extra class names for the <svg> element
+ */
+
+interface SparklineProps {
+  values: number[];
+  width?: number;
+  height?: number;
+  className?: string;
+}
+
+/** Map an input value from [inMin, inMax] to [outMin, outMax]. */
+function mapRange(
+  v: number,
+  inMin: number,
+  inMax: number,
+  outMin: number,
+  outMax: number,
+): number {
+  if (inMax === inMin) return (outMin + outMax) / 2;
+  return ((v - inMin) / (inMax - inMin)) * (outMax - outMin) + outMin;
+}
+
+export default function Sparkline({
+  values,
+  width = 80,
+  height = 28,
+  className = "",
+}: SparklineProps) {
+  // Need at least two data points to draw a meaningful line
+  if (!values || values.length < 2) {
+    return null;
+  }
+
+  const pad = 2; // px padding inside the SVG box
+  const min = Math.min(...values);
+  const max = Math.max(...values);
+
+  // Build the polyline points string
+  const points = values
+    .map((v, i) => {
+      const x = mapRange(i, 0, values.length - 1, pad, width - pad);
+      // SVG y-axis is top-down, so higher values → lower y coordinate
+      const y = mapRange(v, min, max, height - pad, pad);
+      return `${x},${y}`;
+    })
+    .join(" ");
+
+  // Build a closed filled area path (line + baseline)
+  const firstX = pad;
+  const lastX = width - pad;
+  const baseline = height - pad;
+
+  const areaPoints = `${firstX},${baseline} ${points} ${lastX},${baseline}`;
+
+  // Pick stroke colour based on trend: last vs first value
+  const trending = values[values.length - 1] >= values[0];
+  const strokeColor = trending
+    ? "var(--aurora-bright, #34d399)"
+    : "var(--nova-bright, #a78bfa)";
+  const fillColor = trending
+    ? "var(--aurora, #10b981)"
+    : "var(--nova, #7c3aed)";
+
+  return (
+    <svg
+      width={width}
+      height={height}
+      viewBox={`0 0 ${width} ${height}`}
+      className={className}
+      aria-hidden="true"
+      role="img"
+    >
+      {/* Filled area under the curve */}
+      <polygon
+        points={areaPoints}
+        fill={fillColor}
+        fillOpacity={0.12}
+        strokeWidth={0}
+      />
+      {/* The trend line */}
+      <polyline
+        points={points}
+        fill="none"
+        stroke={strokeColor}
+        strokeWidth={1.5}
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+      {/* Dot at the latest value */}
+      {(() => {
+        const lastIdx = values.length - 1;
+        const cx = mapRange(lastIdx, 0, lastIdx, pad, width - pad);
+        const cy = mapRange(values[lastIdx], min, max, height - pad, pad);
+        return (
+          <circle cx={cx} cy={cy} r={2.5} fill={strokeColor} strokeWidth={0} />
+        );
+      })()}
+    </svg>
+  );
+}


### PR DESCRIPTION
- Add GET /api/financials/[projectId]/snapshots route that queries financial_snapshots in Supabase and returns up to 30 daily XLM balance points, oldest-first

- Add Sparkline component (pure SVG, no external deps): renders a filled-area trend line with a terminal dot; green for uptrend, purple for downtrend; returns null for <2 data points so missing data causes zero layout shift

- Update ProjectCard to accept optional snapshots?: Snapshot[] prop and render the sparkline in the card footer between the category tag and star rating

- Update /explore and home page to fetch snapshots for every loaded project in parallel via Promise.allSettled (individual failures are silently swallowed) and pass them to each ProjectCard
closes #201 