### PR TITLE
feat: add submission claiming with auto-release timeout

### DIFF
--- a/web/data/supabase/005_add_claim_fields.sql
+++ b/web/data/supabase/005_add_claim_fields.sql
@@ -1,0 +1,9 @@
+begin;
+
+alter table public.projects
+  add column if not exists claimed_by bigint references public.users ("numericId") on delete set null,
+  add column if not exists claimed_at timestamptz;
+
+create index if not exists projects_claimed_by_idx on public.projects (claimed_by);
+
+commit;

--- a/web/src/app/admin/page.tsx
+++ b/web/src/app/admin/page.tsx
@@ -54,6 +54,8 @@ interface Project {
   rating_count?: number;
   rejection_reason?: string;
   research_images?: string[];
+  claimed_by?: number | null;
+  claimed_by_username?: string | null;
   created_at: string;
 }
 
@@ -120,6 +122,7 @@ function useProjectAction(token: string | null) {
     },
     onSuccess: () => {
       qc.invalidateQueries({ queryKey: ["admin-projects"] });
+      qc.invalidateQueries({ queryKey: ["project-queue"] });
     },
   });
 }
@@ -322,11 +325,14 @@ function StatusBadge({ status, featured }: { status: string; featured?: number }
 function PendingCard({
   project,
   action,
+  currentUserId,
 }: {
   project: Project;
   action: ReturnType<typeof useProjectAction>;
+  currentUserId?: number;
 }) {
   const isLoading = action.isPending;
+  const isMine = project.claimed_by === currentUserId;
 
   return (
     <div className="glass rounded-2xl p-6 transition-all hover:border-dust/40">
@@ -347,6 +353,14 @@ function PendingCard({
             {project.description}
           </p>
           <div className="flex flex-wrap gap-x-4 gap-y-1 text-xs text-ash">
+            {project.claimed_by_username ? (
+              <span className={`flex items-center gap-1 ${isMine ? "text-aurora-bright" : "text-solar-bright"}`}>
+                <span className={`w-1.5 h-1.5 rounded-full ${isMine ? "bg-aurora" : "bg-solar"} animate-pulse`} />
+                {isMine ? "you" : project.claimed_by_username} is reviewing
+              </span>
+            ) : (
+              <span className="text-ash italic">unclaimed</span>
+            )}
             <span>
               by <span className="text-moonlight">{project.username}</span>
             </span>
@@ -387,50 +401,85 @@ function PendingCard({
         </div>
 
         <div className="flex items-center gap-2 shrink-0 flex-wrap">
-          <Link
-            href={`/projects/${project.slug}`}
-            className="btn-ghost text-sm !py-2 !px-3"
-            target="_blank"
-          >
-            Preview
-          </Link>
-          <button
-            disabled={isLoading}
-            onClick={() =>
-              action.mutate({
-                projectId: project.id,
-                action: "approve",
-                body: { featured: false },
-              })
-            }
-            className="bg-aurora/15 hover:bg-aurora/25 text-aurora-bright border border-aurora/20 font-medium text-sm px-4 py-2 rounded-xl transition-all disabled:opacity-50"
-          >
-            Approve
-          </button>
-          <button
-            disabled={isLoading}
-            onClick={() =>
-              action.mutate({
-                projectId: project.id,
-                action: "approve",
-                body: { featured: true },
-              })
-            }
-            className="bg-solar/15 hover:bg-solar/25 text-solar-bright border border-solar/20 font-medium text-sm px-4 py-2 rounded-xl transition-all disabled:opacity-50"
-          >
-            Feature
-          </button>
-          <RejectDialog
-            project={project}
-            isPending={isLoading}
-            onConfirm={(reason) =>
-              action.mutate({
-                projectId: project.id,
-                action: "reject",
-                body: { reason: reason || undefined },
-              })
-            }
-          />
+          {project.claimed_by && !isMine ? (
+            <span className="text-xs text-ash italic">claimed by {project.claimed_by_username}</span>
+          ) : (
+            <>
+              {!project.claimed_by ? (
+                <button
+                  disabled={isLoading}
+                  onClick={() =>
+                    action.mutate({
+                      projectId: project.id,
+                      action: "claim",
+                      body: { action: "claim" },
+                    })
+                  }
+                  className="bg-plasma/15 hover:bg-plasma/25 text-plasma-bright border border-plasma/20 font-medium text-sm px-4 py-2 rounded-xl transition-all disabled:opacity-50"
+                >
+                  Claim
+                </button>
+              ) : (
+                <button
+                  disabled={isLoading}
+                  onClick={() =>
+                    action.mutate({
+                      projectId: project.id,
+                      action: "claim",
+                      body: { action: "release" },
+                    })
+                  }
+                  className="bg-dust/30 hover:bg-dust/50 text-ash hover:text-moonlight border border-dust/20 font-medium text-sm px-4 py-2 rounded-xl transition-all disabled:opacity-50"
+                >
+                  Release
+                </button>
+              )}
+              <Link
+                href={`/projects/${project.slug}`}
+                className="btn-ghost text-sm !py-2 !px-3"
+                target="_blank"
+              >
+                Preview
+              </Link>
+              <button
+                disabled={isLoading}
+                onClick={() =>
+                  action.mutate({
+                    projectId: project.id,
+                    action: "approve",
+                    body: { featured: false },
+                  })
+                }
+                className="bg-aurora/15 hover:bg-aurora/25 text-aurora-bright border border-aurora/20 font-medium text-sm px-4 py-2 rounded-xl transition-all disabled:opacity-50"
+              >
+                Approve
+              </button>
+              <button
+                disabled={isLoading}
+                onClick={() =>
+                  action.mutate({
+                    projectId: project.id,
+                    action: "approve",
+                    body: { featured: true },
+                  })
+                }
+                className="bg-solar/15 hover:bg-solar/25 text-solar-bright border border-solar/20 font-medium text-sm px-4 py-2 rounded-xl transition-all disabled:opacity-50"
+              >
+                Feature
+              </button>
+              <RejectDialog
+                project={project}
+                isPending={isLoading}
+                onConfirm={(reason) =>
+                  action.mutate({
+                    projectId: project.id,
+                    action: "reject",
+                    body: { reason: reason || undefined },
+                  })
+                }
+              />
+            </>
+          )}
         </div>
       </div>
     </div>
@@ -1076,7 +1125,7 @@ export default function AdminPage() {
             ) : filteredPending.length > 0 ? (
               <div className="space-y-4">
                 {filteredPending.map((p) => (
-                  <PendingCard key={p.id} project={p} action={action} />
+                  <PendingCard key={p.id} project={p} action={action} currentUserId={user?.id} />
                 ))}
               </div>
             ) : (

--- a/web/src/app/api/admin/projects/route.ts
+++ b/web/src/app/api/admin/projects/route.ts
@@ -53,9 +53,20 @@ export async function GET(request: Request) {
           const uDoc = await usersCol.ref.doc(String(uid)).get();
           userCache.set(uid, uDoc.exists ? (uDoc.data()!.username as string) : "unknown");
         }
+        const cid = p.claimed_by as number | undefined;
+        if (cid && !userCache.has(cid)) {
+          const uDoc = await usersCol.ref.doc(String(cid)).get();
+          userCache.set(cid, uDoc.exists ? (uDoc.data()!.username as string) : "unknown");
+        }
         const scores = ratingsByProject.get(p.id as number) || [];
         const avg_rating = scores.length > 0 ? scores.reduce((a, b) => a + b, 0) / scores.length : null;
-        return { ...p, username: uid ? userCache.get(uid) : null, avg_rating, rating_count: scores.length };
+        return {
+          ...p,
+          username: uid ? userCache.get(uid) : null,
+          claimed_by_username: cid ? userCache.get(cid) : null,
+          avg_rating,
+          rating_count: scores.length,
+        };
       }),
     );
 

--- a/web/src/app/api/projects/[id]/claim/route.ts
+++ b/web/src/app/api/projects/[id]/claim/route.ts
@@ -1,0 +1,49 @@
+import { projectsCol, usersCol } from "@/lib/db";
+import { getAuthUser } from "@/lib/auth";
+import { isClaimStale } from "@/lib/claims";
+export const dynamic = "force-dynamic";
+
+export async function PUT(
+  request: Request,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const auth = getAuthUser(request);
+  if (!auth || auth.role !== "admin") {
+    return Response.json({ error: "Forbidden" }, { status: 403 });
+  }
+
+  const { id } = await params;
+  const ref = projectsCol.ref.doc(id);
+  const doc = await ref.get();
+  if (!doc.exists) return Response.json({ error: "Project not found" }, { status: 404 });
+
+  const data = doc.data()!;
+  const body = await request.json().catch(() => ({}));
+  const action = body.action as string;
+
+  if (action === "release") {
+    await ref.update({ claimed_by: null, claimed_at: null, updated_at: new Date().toISOString() });
+  } else {
+    const currentClaimant = data.claimed_by as number | null;
+    const claimedAt = data.claimed_at as string | null;
+
+    if (currentClaimant && currentClaimant !== auth.userId && claimedAt && !isClaimStale(claimedAt)) {
+      return Response.json({ error: "This project is already being reviewed by another admin" }, { status: 409 });
+    }
+
+    const now = new Date().toISOString();
+    await ref.update({ claimed_by: auth.userId, claimed_at: now, updated_at: now });
+  }
+
+  const updated = await ref.get();
+  const updatedData = updated.data()!;
+  let claimed_by_username: string | null = null;
+  if (updatedData.claimed_by) {
+    const uDoc = await usersCol.ref.doc(String(updatedData.claimed_by)).get();
+    claimed_by_username = uDoc.exists ? (uDoc.data()!.username as string) : null;
+  }
+
+  return Response.json({
+    project: { ...updatedData, id: updatedData.numericId, claimed_by_username },
+  });
+}

--- a/web/src/app/api/projects/pending/route.ts
+++ b/web/src/app/api/projects/pending/route.ts
@@ -1,5 +1,7 @@
 import { projectsCol, usersCol } from "@/lib/db";
 import { getAuthUser } from "@/lib/auth";
+import { isClaimStale } from "@/lib/claims";
+import { getSupabase } from "@/lib/firebase";
 export const dynamic = "force-dynamic";
 
 export async function GET(request: Request) {
@@ -13,15 +15,40 @@ export async function GET(request: Request) {
     .orderBy("created_at", "desc")
     .get();
 
+  const supabase = getSupabase();
+
   const projects = await Promise.all(
     snap.docs.map(async (d) => {
       const p = d.data();
-      let username = null;
+
+      const claimed_by = p.claimed_by as number | null;
+      const claimed_at = p.claimed_at as string | null;
+
+      if (claimed_by && claimed_at && isClaimStale(claimed_at)) {
+        await supabase
+          .from("projects")
+          .update({ claimed_by: null, claimed_at: null })
+          .eq("numericId", p.numericId as number);
+        (p as any).claimed_by = null;
+        (p as any).claimed_at = null;
+      }
+
+      const userCache = new Map<number, string>();
       if (p.user_id) {
         const uDoc = await usersCol.ref.doc(String(p.user_id)).get();
-        username = uDoc.exists ? uDoc.data()!.username : null;
+        userCache.set(p.user_id as number, uDoc.exists ? uDoc.data()!.username : null);
       }
-      return { ...p, id: p.numericId, username };
+      if (p.claimed_by) {
+        const uDoc = await usersCol.ref.doc(String(p.claimed_by)).get();
+        userCache.set(p.claimed_by as number, uDoc.exists ? uDoc.data()!.username : "unknown");
+      }
+
+      return {
+        ...p,
+        id: p.numericId,
+        username: p.user_id ? userCache.get(p.user_id as number) : null,
+        claimed_by_username: p.claimed_by ? userCache.get(p.claimed_by as number) : null,
+      };
     })
   );
 

--- a/web/src/app/api/projects/queue/route.ts
+++ b/web/src/app/api/projects/queue/route.ts
@@ -1,4 +1,6 @@
 import { projectsCol, usersCol } from "@/lib/db";
+import { isClaimStale } from "@/lib/claims";
+import { getSupabase } from "@/lib/firebase";
 export const dynamic = "force-dynamic";
 
 export async function GET() {
@@ -7,15 +9,41 @@ export async function GET() {
       .where("status", "==", "submitted")
       .get();
 
+    const supabase = getSupabase();
+    const now = new Date().toISOString();
+
     const userCache = new Map<number, string>();
     const projects = await Promise.all(
       snap.docs.map(async (d) => {
         const p = d.data();
+
+        const claimed_by = p.claimed_by as number | null;
+        const claimed_at = p.claimed_at as string | null;
+
+        if (claimed_by && claimed_at && isClaimStale(claimed_at)) {
+          await supabase
+            .from("projects")
+            .update({ claimed_by: null, claimed_at: null })
+            .eq("numericId", p.numericId as number);
+          (p as any).claimed_by = null;
+          (p as any).claimed_at = null;
+        }
+
         const uid = p.user_id as number;
         if (uid && !userCache.has(uid)) {
           const uDoc = await usersCol.ref.doc(String(uid)).get();
           userCache.set(uid, uDoc.exists ? (uDoc.data()!.username as string) : "unknown");
         }
+
+        let claimed_by_username: string | null = null;
+        if (p.claimed_by) {
+          if (!userCache.has(p.claimed_by as number)) {
+            const uDoc = await usersCol.ref.doc(String(p.claimed_by)).get();
+            userCache.set(p.claimed_by as number, uDoc.exists ? (uDoc.data()!.username as string) : "unknown");
+          }
+          claimed_by_username = userCache.get(p.claimed_by as number)!;
+        }
+
         return {
           id: p.numericId,
           name: p.name,
@@ -26,6 +54,9 @@ export async function GET() {
           github_url: p.github_url,
           github_repos: p.github_repos || [],
           username: uid ? userCache.get(uid) : null,
+          claimed_by: p.claimed_by as number | null,
+          claimed_by_username,
+          claimed_at: p.claimed_at as string | null,
           created_at: p.created_at,
         };
       }),

--- a/web/src/app/queue/page.tsx
+++ b/web/src/app/queue/page.tsx
@@ -13,6 +13,7 @@ interface QueueProject {
   github_url?: string;
   github_repos?: { label: string; url: string }[];
   username: string | null;
+  claimed_by_username: string | null;
   created_at: string;
 }
 
@@ -112,6 +113,12 @@ export default function QueuePage() {
                   </p>
 
                   <div className="flex flex-wrap items-center gap-x-4 gap-y-1 text-xs text-ash">
+                    {project.claimed_by_username && (
+                      <span className="flex items-center gap-1">
+                        <span className="w-1.5 h-1.5 rounded-full bg-solar animate-pulse" />
+                        reviewing: <span className="text-solar-bright font-medium">{project.claimed_by_username}</span>
+                      </span>
+                    )}
                     {project.username && (
                       <span>
                         by <span className="text-moonlight">{project.username}</span>

--- a/web/src/lib/claims.ts
+++ b/web/src/lib/claims.ts
@@ -1,0 +1,5 @@
+export const CLAIM_TIMEOUT_MS = 30 * 60 * 1000;
+
+export function isClaimStale(claimedAt: string): boolean {
+  return Date.now() - new Date(claimedAt).getTime() > CLAIM_TIMEOUT_MS;
+}


### PR DESCRIPTION
## Summary

Add ability for admins to claim/review submissions in the approval queue, preventing duplicate reviews.

## Changes

- **Migration** (`005_add_claim_fields.sql`): Adds `claimed_by` (FK → users) and `claimed_at` columns to the `projects` table
- **Claim API** (`/api/projects/[id]/claim`): PUT endpoint — claim (locks to you), release (unlocks), or get 409 conflict if someone else has a non-stale claim
- **Auto-release**: Stale claims (>30 min) are released automatically when the queue or pending endpoints are fetched
- **Queue page** (`/queue`): Shows a pulsing dot + "reviewing: [username]" when a submission is claimed
- **Admin dashboard** (`/admin`): Pending tab shows claim status per card; Claim/Release buttons; non-claimers see "claimed by X" and cannot claim until released or stale
To test: Run 005_add_claim_fields.sql in Supabase SQL Editor, then visit /admin → Pending tab.

closes #243