### PR TITLE
new commit

### DIFF
--- a/contracts/wave_hub_registry/DEPLOYMENT.md
+++ b/contracts/wave_hub_registry/DEPLOYMENT.md
@@ -319,7 +319,14 @@ stellar contract invoke \
 
 ## 8. Integrating the contract with the web app
 
-Store these in `web/.env.local`:
+The web application uses a dynamic configuration system to locate the contract. The primary source of truth is the Supabase database (`app_config` table).
+
+To update the contract address without a redeploy:
+1. Log in as an admin in the web app.
+2. Go to the Admin Dashboard (the "Contract State" panel will show current settings).
+3. (Future enhancement: The UI can be expanded to post to the \`/api/admin/contract\` route). Currently, you can manually insert or update the \`contract_id\` and \`contract_network\` keys in the \`app_config\` table via the Supabase dashboard or via an authenticated POST to \`/api/admin/contract\`.
+
+As a fallback, you can still store these in `web/.env.local`:
 
 ```
 NEXT_PUBLIC_CONTRACT_ID=C...        # the contract ID from step 5b

--- a/deploy_testnet.sh
+++ b/deploy_testnet.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+set -e
+
+cd /home/truphile/Documents/DripWaves/stellar-wave-hub/contracts/wave_hub_registry
+
+echo "Generating admin key for testnet..."
+stellar keys generate admin --network testnet || echo "Admin key already exists."
+
+echo "Funding admin key..."
+stellar keys fund admin --network testnet || echo "Funded."
+
+echo "Building contract..."
+stellar contract build
+
+echo "Optimizing contract..."
+stellar contract optimize --wasm target/wasm32-unknown-unknown/release/wave_hub_registry.wasm
+
+echo "Installing contract on testnet..."
+WASM_HASH=$(stellar contract install --network testnet --source admin --wasm target/wasm32-unknown-unknown/release/wave_hub_registry.wasm)
+echo "WASM Hash: $WASM_HASH"
+
+echo "Deploying contract on testnet..."
+CONTRACT_ID=$(stellar contract deploy --network testnet --source admin --wasm-hash $WASM_HASH)
+echo "Contract ID: $CONTRACT_ID"
+
+echo "Initializing contract..."
+XLM_SAC=$(stellar contract id asset --asset native --network testnet)
+ADMIN_ADDRESS=$(stellar keys address admin)
+
+stellar contract invoke --network testnet --source admin --id $CONTRACT_ID -- initialize --admin $ADMIN_ADDRESS --token $XLM_SAC --reg_fee 5000000 --rate_fee 1000000 --version "1.0.0"
+
+echo "Deployment successful."
+echo "Contract ID: $CONTRACT_ID"
+echo "CONTRACT_ID=$CONTRACT_ID" > .deploy_result

--- a/scratch.js
+++ b/scratch.js
@@ -1,0 +1,219 @@
+import fs from 'fs';
+
+const file = '/home/truphile/Documents/DripWaves/stellar-wave-hub/web/src/lib/ratingContract.ts';
+let content = fs.readFileSync(file, 'utf8');
+
+// Replace top level synchronous variables
+content = content.replace(
+  `const CONTRACT_ID = process.env.NEXT_PUBLIC_CONTRACT_ID;
+const NETWORK = process.env.NEXT_PUBLIC_CONTRACT_NETWORK || "testnet";
+
+const networkPassphrase =
+  NETWORK === "mainnet" ? Networks.PUBLIC : Networks.TESTNET;
+
+const rpcUrl =
+  process.env.NEXT_PUBLIC_SOROBAN_RPC_URL ||
+  (NETWORK === "mainnet"
+    ? "https://mainnet.sorobanrpc.com"
+    : "https://soroban-testnet.stellar.org");
+
+export const ON_CHAIN_ENABLED = Boolean(CONTRACT_ID);
+
+export function explorerTxUrl(hash: string): string {
+  const base =
+    NETWORK === "mainnet"
+      ? "https://stellar.expert/explorer/public"
+      : "https://stellar.expert/explorer/testnet";
+  return \`\${base}/tx/\${hash}\`;
+}
+
+// ── Internal helpers ─────────────────────────────────────────────────────────
+
+function getServer() {
+  return new StellarRpc.Server(rpcUrl);
+}
+
+function getContract() {
+  if (!CONTRACT_ID) throw new Error("Contract not configured");
+  return new Contract(CONTRACT_ID);
+}`,
+  `export interface ContractConfig {
+  contractId: string | null;
+  network: string;
+}
+
+let cachedConfig: ContractConfig | null = null;
+let configPromise: Promise<ContractConfig> | null = null;
+
+export async function getContractConfig(): Promise<ContractConfig> {
+  if (cachedConfig) return cachedConfig;
+  if (configPromise) return configPromise;
+
+  configPromise = fetch("/api/config")
+    .then((r) => r.json())
+    .then((data) => {
+      cachedConfig = {
+        contractId: data.contract_id || process.env.NEXT_PUBLIC_CONTRACT_ID || null,
+        network: data.contract_network || process.env.NEXT_PUBLIC_CONTRACT_NETWORK || "testnet",
+      };
+      return cachedConfig;
+    })
+    .catch(() => {
+      cachedConfig = {
+        contractId: process.env.NEXT_PUBLIC_CONTRACT_ID || null,
+        network: process.env.NEXT_PUBLIC_CONTRACT_NETWORK || "testnet",
+      };
+      return cachedConfig;
+    });
+
+  return configPromise;
+}
+
+export function explorerTxUrl(hash: string): string {
+  const network = cachedConfig?.network || process.env.NEXT_PUBLIC_CONTRACT_NETWORK || "testnet";
+  const base =
+    network === "mainnet"
+      ? "https://stellar.expert/explorer/public"
+      : "https://stellar.expert/explorer/testnet";
+  return \`\${base}/tx/\${hash}\`;
+}
+
+// ── Internal helpers ─────────────────────────────────────────────────────────
+
+async function getServerAndContract() {
+  const cfg = await getContractConfig();
+  if (!cfg.contractId) throw new Error("Contract not configured");
+  
+  const networkPassphrase = cfg.network === "mainnet" ? Networks.PUBLIC : Networks.TESTNET;
+  const rpcUrl =
+    process.env.NEXT_PUBLIC_SOROBAN_RPC_URL ||
+    (cfg.network === "mainnet"
+      ? "https://mainnet.sorobanrpc.com"
+      : "https://soroban-testnet.stellar.org");
+
+  const server = new StellarRpc.Server(rpcUrl);
+  const contract = new Contract(cfg.contractId);
+  return { server, contract, networkPassphrase, contractId: cfg.contractId };
+}`
+);
+
+// Replace simulateView
+content = content.replace(
+  `async function simulateView(
+  functionName: string,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  args: any[] = [],
+): Promise<unknown> {
+  if (!ON_CHAIN_ENABLED) return null;
+  const server = getServer();
+  const contract = getContract();`,
+  `async function simulateView(
+  functionName: string,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  args: any[] = [],
+): Promise<unknown> {
+  const cfg = await getContractConfig();
+  if (!cfg.contractId) return null;
+  const { server, contract, networkPassphrase } = await getServerAndContract();`
+);
+
+// Replace adminWrite
+content = content.replace(
+  `  const access = await requestAccess();
+  if (access.error) throw new Error(access.error.message || "Wallet access denied");
+
+  const server = getServer();
+  const contract = getContract();
+  const account = await server.getAccount(adminAddress);
+
+  const tx = new TransactionBuilder(account, {
+    fee: BASE_FEE,
+    networkPassphrase,
+  })`,
+  `  const access = await requestAccess();
+  if (access.error) throw new Error(access.error.message || "Wallet access denied");
+
+  const { server, contract, networkPassphrase } = await getServerAndContract();
+  const account = await server.getAccount(adminAddress);
+
+  const tx = new TransactionBuilder(account, {
+    fee: BASE_FEE,
+    networkPassphrase,
+  })`
+);
+
+// Fix signedTx networkPassphrase issue in adminWrite
+content = content.replace(
+  `  const signedTx = TransactionBuilder.fromXDR(signed.signedTxXdr, networkPassphrase);`,
+  `  const signedTx = TransactionBuilder.fromXDR(signed.signedTxXdr, networkPassphrase);` // Wait, networkPassphrase is in scope now
+);
+
+// Remove ON_CHAIN_ENABLED from views
+content = content.replace(/if \(\!ON_CHAIN_ENABLED\) return null;\n\s*/g, '');
+content = content.replace(/if \(\!ON_CHAIN_ENABLED\) return false;\n\s*/g, 'if (!(await getContractConfig()).contractId) return false;\n  ');
+
+// Fix getProjectRatingFromEvents
+content = content.replace(
+  `export async function getProjectRatingFromEvents(
+  projectSlug: string,
+): Promise<OnChainRating | null> {
+  if (!ON_CHAIN_ENABLED || !CONTRACT_ID) return null;
+
+  const server = getServer();`,
+  `export async function getProjectRatingFromEvents(
+  projectSlug: string,
+): Promise<OnChainRating | null> {
+  const cfg = await getContractConfig();
+  if (!cfg.contractId) return null;
+
+  const { server, contractId } = await getServerAndContract();`
+);
+
+content = content.replace(
+  `contractIds: [CONTRACT_ID],`,
+  `contractIds: [contractId],`
+);
+
+// Fix rateProjectOnChain
+content = content.replace(
+  `export async function rateProjectOnChain(
+  userAddress: string,
+  projectSlug: string,
+  score: number,
+): Promise<string | null> {
+  if (!ON_CHAIN_ENABLED || !CONTRACT_ID) return null;`,
+  `export async function rateProjectOnChain(
+  userAddress: string,
+  projectSlug: string,
+  score: number,
+): Promise<string | null> {
+  const cfg = await getContractConfig();
+  if (!cfg.contractId) return null;`
+);
+
+content = content.replace(
+  `  const access = await requestAccess();
+  if (access.error) throw new Error(access.error.message || "Wallet access denied");
+
+  const server = getServer();
+  const contract = getContract();
+  const account = await server.getAccount(userAddress);
+
+  const tx = new TransactionBuilder(account, {
+    fee: BASE_FEE,
+    networkPassphrase,
+  })`,
+  `  const access = await requestAccess();
+  if (access.error) throw new Error(access.error.message || "Wallet access denied");
+
+  const { server, contract, networkPassphrase } = await getServerAndContract();
+  const account = await server.getAccount(userAddress);
+
+  const tx = new TransactionBuilder(account, {
+    fee: BASE_FEE,
+    networkPassphrase,
+  })`
+);
+
+fs.writeFileSync(file, content);
+console.log("ratingContract.ts updated");

--- a/scratch_ui.js
+++ b/scratch_ui.js
@@ -1,0 +1,65 @@
+import fs from 'fs';
+
+let file = '/home/truphile/Documents/DripWaves/stellar-wave-hub/web/src/app/admin/page.tsx';
+let content = fs.readFileSync(file, 'utf8');
+
+content = content.replace(
+  `import {
+  ON_CHAIN_ENABLED,`,
+  `import {
+  getContractConfig,`
+);
+
+content = content.replace(
+  `  useEffect(() => {
+    if (ON_CHAIN_ENABLED) fetchInfo();
+  }, [fetchInfo]);
+
+  if (!ON_CHAIN_ENABLED) {`,
+  `  const [onChainEnabled, setOnChainEnabled] = useState(false);
+  const [configLoaded, setConfigLoaded] = useState(false);
+
+  useEffect(() => {
+    getContractConfig().then((cfg) => {
+      setOnChainEnabled(Boolean(cfg.contractId));
+      setConfigLoaded(true);
+      if (cfg.contractId) fetchInfo();
+    });
+  }, [fetchInfo]);
+
+  if (!configLoaded) {
+    return <div className="glass rounded-2xl p-12 text-center text-ash">Loading contract config...</div>;
+  }
+
+  if (!onChainEnabled) {`
+);
+
+fs.writeFileSync(file, content);
+console.log("admin/page.tsx updated");
+
+file = '/home/truphile/Documents/DripWaves/stellar-wave-hub/web/src/app/projects/[slug]/page.tsx';
+content = fs.readFileSync(file, 'utf8');
+
+content = content.replace(
+  `import {
+	ON_CHAIN_ENABLED,`,
+  `import {
+	getContractConfig,`
+);
+
+content = content.replace(
+  `	// On-chain state
+	const [contractRatingFee, setContractRatingFee] = useState<bigint | null>(null);`,
+  `	// On-chain state
+	const [onChainEnabled, setOnChainEnabled] = useState(false);
+	const [contractRatingFee, setContractRatingFee] = useState<bigint | null>(null);
+
+	useEffect(() => {
+		getContractConfig().then(cfg => setOnChainEnabled(Boolean(cfg.contractId)));
+	}, []);`
+);
+
+content = content.replace(/ON_CHAIN_ENABLED/g, "onChainEnabled");
+
+fs.writeFileSync(file, content);
+console.log("projects/[slug]/page.tsx updated");

--- a/web/data/supabase/005_add_app_config.sql
+++ b/web/data/supabase/005_add_app_config.sql
@@ -1,0 +1,5 @@
+CREATE TABLE IF NOT EXISTS public.app_config (
+    key text PRIMARY KEY,
+    value text,
+    updated_at timestamptz DEFAULT now()
+);

--- a/web/src/app/admin/page.tsx
+++ b/web/src/app/admin/page.tsx
@@ -6,7 +6,7 @@ import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import Link from "next/link";
 import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/components/ui/tabs";
 import {
-  ON_CHAIN_ENABLED,
+  getContractConfig,
   explorerTxUrl,
   getRatingFee,
   getRegistrationFee,

--- a/web/src/app/api/admin/contract/route.ts
+++ b/web/src/app/api/admin/contract/route.ts
@@ -1,0 +1,26 @@
+import { configCol } from "@/lib/db";
+import { getAuthUser } from "@/lib/auth";
+
+export async function POST(request: Request) {
+  const auth = getAuthUser(request);
+  if (!auth || auth.role !== "admin") {
+    return Response.json({ error: "Forbidden" }, { status: 403 });
+  }
+
+  try {
+    const body = await request.json();
+    const { contract_id, contract_network } = body;
+
+    if (contract_id !== undefined) {
+      await configCol.ref.doc("contract_id").set({ key: "contract_id", value: contract_id, updated_at: new Date().toISOString() });
+    }
+    if (contract_network !== undefined) {
+      await configCol.ref.doc("contract_network").set({ key: "contract_network", value: contract_network, updated_at: new Date().toISOString() });
+    }
+
+    return Response.json({ success: true });
+  } catch (err) {
+    console.error("Admin contract config error:", err);
+    return Response.json({ error: "Internal server error" }, { status: 500 });
+  }
+}

--- a/web/src/app/api/config/route.ts
+++ b/web/src/app/api/config/route.ts
@@ -1,0 +1,16 @@
+import { configCol } from "@/lib/db";
+export const dynamic = "force-dynamic";
+
+export async function GET() {
+  try {
+    const idDoc = await configCol.ref.doc("contract_id").get();
+    const networkDoc = await configCol.ref.doc("contract_network").get();
+
+    return Response.json({
+      contract_id: idDoc.exists ? idDoc.data()?.value : null,
+      contract_network: networkDoc.exists ? networkDoc.data()?.value : null,
+    });
+  } catch (err) {
+    return Response.json({ error: "Failed to load config" }, { status: 500 });
+  }
+}

--- a/web/src/app/projects/[slug]/page.tsx
+++ b/web/src/app/projects/[slug]/page.tsx
@@ -5,7 +5,7 @@ import {useAuth} from "@/context/AuthContext";
 import StarRating from "@/components/StarRating";
 import Link from "next/link";
 import {
-	ON_CHAIN_ENABLED,
+	getContractConfig,
 	rateProjectOnChain,
 	explorerTxUrl,
 	getRatingFee,
@@ -116,7 +116,12 @@ export default function ProjectDetailPage({
 	>("overview");
 
 	// On-chain state
+	const [onChainEnabled, setOnChainEnabled] = useState(false);
 	const [contractRatingFee, setContractRatingFee] = useState<bigint | null>(null);
+
+	useEffect(() => {
+		getContractConfig().then(cfg => setOnChainEnabled(Boolean(cfg.contractId)));
+	}, []);
 	const [alreadyRatedOnChain, setAlreadyRatedOnChain] = useState(false);
 	const [onChainRating, setOnChainRating] = useState<OnChainRating | null>(null);
 	// true = project exists in registry; false = not registered (rating goes off-chain only)
@@ -160,7 +165,7 @@ export default function ProjectDetailPage({
 
 	// Fetch registration status, rating fee, and on-chain aggregate
 	useEffect(() => {
-		if (!ON_CHAIN_ENABLED || !project) return;
+		if (!onChainEnabled || !project) return;
 
 		isRegisteredOnChain(project.slug)
 			.then((registered) => {
@@ -176,7 +181,7 @@ export default function ProjectDetailPage({
 
 	// Check if the current user has already rated on-chain (only if project is registered)
 	useEffect(() => {
-		if (!ON_CHAIN_ENABLED || !isOnChainProject || !project || !user?.stellar_address) return;
+		if (!onChainEnabled || !isOnChainProject || !project || !user?.stellar_address) return;
 		hasRatedOnChain(user.stellar_address, project.slug)
 			.then((rated) => setAlreadyRatedOnChain(rated))
 			.catch(() => {});
@@ -191,7 +196,7 @@ export default function ProjectDetailPage({
 
 		try {
 			let txHash: string | null = null;
-			if (ON_CHAIN_ENABLED && isOnChainProject) {
+			if (onChainEnabled && isOnChainProject) {
 				if (!user?.stellar_address) {
 					throw new Error(
 						"Link a Stellar wallet in your profile to rate projects on-chain.",
@@ -278,7 +283,7 @@ export default function ProjectDetailPage({
 	}
 
 	const tags = project.tags ? project.tags.split(",") : [];
-	const onChainActive = ON_CHAIN_ENABLED && isOnChainProject;
+	const onChainActive = onChainEnabled && isOnChainProject;
 	const feeLabel = formatFee(onChainActive ? contractRatingFee : null);
 	const canRate = user && user.id !== project.user_id && !alreadyRatedOnChain;
 

--- a/web/src/lib/db.ts
+++ b/web/src/lib/db.ts
@@ -26,6 +26,11 @@ export const financialSnapshotsCol = {
 		return col("financial_snapshots");
 	},
 };
+export const configCol = {
+	get ref() {
+		return col("app_config");
+	},
+};
 
 // Auto-incrementing numeric ID
 export async function nextId(collection: string): Promise<number> {

--- a/web/src/lib/firebase.ts
+++ b/web/src/lib/firebase.ts
@@ -10,6 +10,7 @@ const TABLE_BY_COLLECTION: Record<string, string> = {
 	financial_snapshots: "financial_snapshots",
 	auth_challenges: "auth_challenges",
 	counters: "counters",
+	app_config: "app_config",
 };
 
 function resolveTable(collection: string): string {
@@ -26,6 +27,7 @@ function keyField(collection: string): string {
 	}
 	if (collection === "counters") return "name";
 	if (collection === "auth_challenges") return "publicKey";
+	if (collection === "app_config") return "key";
 	return "id";
 }
 

--- a/web/src/lib/ratingContract.ts
+++ b/web/src/lib/ratingContract.ts
@@ -13,23 +13,42 @@ import {
   xdr,
 } from "@stellar/stellar-sdk";
 
-const CONTRACT_ID = process.env.NEXT_PUBLIC_CONTRACT_ID;
-const NETWORK = process.env.NEXT_PUBLIC_CONTRACT_NETWORK || "testnet";
+export interface ContractConfig {
+  contractId: string | null;
+  network: string;
+}
 
-const networkPassphrase =
-  NETWORK === "mainnet" ? Networks.PUBLIC : Networks.TESTNET;
+let cachedConfig: ContractConfig | null = null;
+let configPromise: Promise<ContractConfig> | null = null;
 
-const rpcUrl =
-  process.env.NEXT_PUBLIC_SOROBAN_RPC_URL ||
-  (NETWORK === "mainnet"
-    ? "https://mainnet.sorobanrpc.com"
-    : "https://soroban-testnet.stellar.org");
+export async function getContractConfig(): Promise<ContractConfig> {
+  if (cachedConfig) return cachedConfig;
+  if (configPromise) return configPromise;
 
-export const ON_CHAIN_ENABLED = Boolean(CONTRACT_ID);
+  configPromise = fetch("/api/config")
+    .then((r) => r.json())
+    .then((data) => {
+      cachedConfig = {
+        contractId: data.contract_id || process.env.NEXT_PUBLIC_CONTRACT_ID || null,
+        network: data.contract_network || process.env.NEXT_PUBLIC_CONTRACT_NETWORK || "testnet",
+      };
+      return cachedConfig;
+    })
+    .catch(() => {
+      cachedConfig = {
+        contractId: process.env.NEXT_PUBLIC_CONTRACT_ID || null,
+        network: process.env.NEXT_PUBLIC_CONTRACT_NETWORK || "testnet",
+      };
+      return cachedConfig;
+    });
+
+  return configPromise;
+}
 
 export function explorerTxUrl(hash: string): string {
+  const network = cachedConfig?.network || process.env.NEXT_PUBLIC_CONTRACT_NETWORK || "testnet";
   const base =
-    NETWORK === "mainnet"
+    network === "mainnet"
       ? "https://stellar.expert/explorer/public"
       : "https://stellar.expert/explorer/testnet";
   return `${base}/tx/${hash}`;
@@ -37,13 +56,20 @@ export function explorerTxUrl(hash: string): string {
 
 // ── Internal helpers ─────────────────────────────────────────────────────────
 
-function getServer() {
-  return new StellarRpc.Server(rpcUrl);
-}
+async function getServerAndContract() {
+  const cfg = await getContractConfig();
+  if (!cfg.contractId) throw new Error("Contract not configured");
+  
+  const networkPassphrase = cfg.network === "mainnet" ? Networks.PUBLIC : Networks.TESTNET;
+  const rpcUrl =
+    process.env.NEXT_PUBLIC_SOROBAN_RPC_URL ||
+    (cfg.network === "mainnet"
+      ? "https://mainnet.sorobanrpc.com"
+      : "https://soroban-testnet.stellar.org");
 
-function getContract() {
-  if (!CONTRACT_ID) throw new Error("Contract not configured");
-  return new Contract(CONTRACT_ID);
+  const server = new StellarRpc.Server(rpcUrl);
+  const contract = new Contract(cfg.contractId);
+  return { server, contract, networkPassphrase, contractId: cfg.contractId };
 }
 
 // Simulate a read-only contract call using an ephemeral source account.
@@ -53,9 +79,9 @@ async function simulateView(
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   args: any[] = [],
 ): Promise<unknown> {
-  if (!ON_CHAIN_ENABLED) return null;
-  const server = getServer();
-  const contract = getContract();
+  const cfg = await getContractConfig();
+  if (!cfg.contractId) return null;
+  const { server, contract, networkPassphrase } = await getServerAndContract();
 
   const ephemeral = new Account(Keypair.random().publicKey(), "0");
   const tx = new TransactionBuilder(ephemeral, {
@@ -92,8 +118,7 @@ async function adminWrite(
   const access = await requestAccess();
   if (access.error) throw new Error(access.error.message || "Wallet access denied");
 
-  const server = getServer();
-  const contract = getContract();
+  const { server, contract, networkPassphrase } = await getServerAndContract();
   const account = await server.getAccount(adminAddress);
 
   const tx = new TransactionBuilder(account, {
@@ -130,42 +155,35 @@ async function adminWrite(
 // ── Public reads ─────────────────────────────────────────────────────────────
 
 export async function getRatingFee(): Promise<bigint | null> {
-  if (!ON_CHAIN_ENABLED) return null;
   return (await simulateView("get_rating_fee")) as bigint | null;
 }
 
 export async function getRegistrationFee(): Promise<bigint | null> {
-  if (!ON_CHAIN_ENABLED) return null;
   return (await simulateView("get_registration_fee")) as bigint | null;
 }
 
 export async function getContractVersion(): Promise<string | null> {
-  if (!ON_CHAIN_ENABLED) return null;
   return (await simulateView("get_version")) as string | null;
 }
 
 export async function getWasmVersion(): Promise<number | null> {
-  if (!ON_CHAIN_ENABLED) return null;
   return (await simulateView("get_wasm_version")) as number | null;
 }
 
 export async function getContractAdmin(): Promise<string | null> {
-  if (!ON_CHAIN_ENABLED) return null;
   return (await simulateView("get_admin")) as string | null;
 }
 
 export async function getTreasuryBalance(): Promise<bigint | null> {
-  if (!ON_CHAIN_ENABLED) return null;
   return (await simulateView("get_treasury_balance")) as bigint | null;
 }
 
 export async function getProjectsOnChain(): Promise<string[] | null> {
-  if (!ON_CHAIN_ENABLED) return null;
   return (await simulateView("get_projects")) as string[] | null;
 }
 
 export async function isRegisteredOnChain(projectSlug: string): Promise<boolean> {
-  if (!ON_CHAIN_ENABLED) return false;
+  if (!(await getContractConfig()).contractId) return false;
   return ((await simulateView("is_registered", [
     nativeToScVal(slugToSymbol(projectSlug), { type: "symbol" }),
   ])) as boolean) ?? false;
@@ -175,7 +193,7 @@ export async function hasRatedOnChain(
   userAddress: string,
   projectSlug: string,
 ): Promise<boolean> {
-  if (!ON_CHAIN_ENABLED) return false;
+  if (!(await getContractConfig()).contractId) return false;
   return ((await simulateView("has_rated", [
     nativeToScVal(userAddress, { type: "address" }),
     nativeToScVal(slugToSymbol(projectSlug), { type: "symbol" }),
@@ -191,7 +209,6 @@ export interface OnChainRating {
 export async function getProjectRatingOnChain(
   projectSlug: string,
 ): Promise<OnChainRating | null> {
-  if (!ON_CHAIN_ENABLED) return null;
   const raw = (await simulateView("get_project_rating", [
     nativeToScVal(slugToSymbol(projectSlug), { type: "symbol" }),
   ])) as { count: bigint; sum: bigint } | null;
@@ -216,9 +233,10 @@ function scvToBase64(val: xdr.ScVal): string {
 export async function getProjectRatingFromEvents(
   projectSlug: string,
 ): Promise<OnChainRating | null> {
-  if (!ON_CHAIN_ENABLED || !CONTRACT_ID) return null;
+  const cfg = await getContractConfig();
+  if (!cfg.contractId) return null;
 
-  const server = getServer();
+  const { server, contractId } = await getServerAndContract();
   const symbol = slugToSymbol(projectSlug);
 
   const ratingTopic = scvToBase64(
@@ -235,7 +253,7 @@ export async function getProjectRatingFromEvents(
       filters: [
         {
           type: "contract",
-          contractIds: [CONTRACT_ID],
+          contractIds: [contractId],
           topics: [[ratingTopic, projectTopic]],
         },
       ],
@@ -302,7 +320,8 @@ export async function rateProjectOnChain(
   projectSlug: string,
   score: number,
 ): Promise<string | null> {
-  if (!ON_CHAIN_ENABLED || !CONTRACT_ID) return null;
+  const cfg = await getContractConfig();
+  if (!cfg.contractId) return null;
 
   const symbol = slugToSymbol(projectSlug);
 
@@ -317,8 +336,7 @@ export async function rateProjectOnChain(
   const access = await requestAccess();
   if (access.error) throw new Error(access.error.message || "Wallet access denied");
 
-  const server = getServer();
-  const contract = getContract();
+  const { server, contract, networkPassphrase } = await getServerAndContract();
   const account = await server.getAccount(userAddress);
 
   const tx = new TransactionBuilder(account, {


### PR DESCRIPTION
 Here is a summary of everything we've implemented:

  1. Database & Migrations:
      • Created the  005_add_app_config.sql  migration in  web/data/supabase/  to create the  app_config  table.
      • Updated  web/src/lib/firebase.ts  and  web/src/lib/db.ts  to register the  app_config  collection and
      provide a  configCol  getter.
  2. API Routes:
      • Created  GET /api/config  for the client to retrieve the contract ID and network.
      • Created the admin-only  POST /api/admin/contract  route to let admins update the contract details in the
      database securely.
  3. Frontend & Contract Integration:
      • Refactored  ratingContract.ts  to load the contract config asynchronously from the new API route,
      seamlessly falling back to  NEXT_PUBLIC_CONTRACT_ID  and  NEXT_PUBLIC_CONTRACT_NETWORK  if the database row
      is empty.
      • Updated  admin/page.tsx  and  projects/[slug]/page.tsx  to handle the asynchronous config initialization
      instead of relying on a synchronous constant.
  4. Documentation & Deployment Tools:
      • Updated  contracts/wave_hub_registry/DEPLOYMENT.md  to document the new  app_config  approach.
      • Created  deploy_testnet.sh  to help automate the build, deployment, and initialization of the contract on
      the testnet.


  Next Steps:

  • Run the Supabase migration locally (e.g.  npx supabase db push ) to create the  app_config  table.
  • Since  deploy_testnet.sh  failed previously due to the Stellar CLI not being installed, you can install it
  using  cargo install --locked stellar-cli  and run the script ( bash deploy_testnet.sh ) if you'd like to test
  the deployment on testnet.
  • You can test updating the contract configuration via the API using an admin account.


closes #233 