### PR TITLE
feat: two-person approval for sensitive actions (#248)

### DIFF
--- a/web/data/supabase/006_add_approval_workflow.sql
+++ b/web/data/supabase/006_add_approval_workflow.sql
@@ -1,0 +1,42 @@
+-- Migration: Two-person approval workflow for sensitive actions
+-- Adds approval_requests table and counter
+
+begin;
+
+create table if not exists public.approval_requests (
+  "numericId" bigint primary key,
+  project_id bigint not null,
+  action_type text not null check (action_type in ('feature', 'unfeature', 'delete')),
+  requested_by bigint not null,
+  status text not null default 'pending' check (status in ('pending', 'approved', 'rejected')),
+  reason text,
+  reviewer_id bigint,
+  reviewer_note text,
+  reviewed_at timestamptz,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  constraint approval_requests_project_id_fkey
+    foreign key (project_id)
+    references public.projects ("numericId")
+    on delete cascade,
+  constraint approval_requests_requested_by_fkey
+    foreign key (requested_by)
+    references public.users ("numericId")
+    on delete cascade,
+  constraint approval_requests_reviewer_id_fkey
+    foreign key (reviewer_id)
+    references public.users ("numericId")
+    on delete set null
+);
+
+create index if not exists approval_requests_project_id_idx on public.approval_requests (project_id);
+create index if not exists approval_requests_status_idx on public.approval_requests (status);
+create index if not exists approval_requests_requested_by_idx on public.approval_requests (requested_by);
+create index if not exists approval_requests_created_at_idx on public.approval_requests (created_at desc);
+
+-- Counter for auto-incrementing IDs
+insert into public.counters (name, value)
+values ('approval_requests', 0)
+on conflict (name) do nothing;
+
+commit;

--- a/web/src/app/admin/page.tsx
+++ b/web/src/app/admin/page.tsx
@@ -6,6 +6,7 @@ import { hasMinRole } from "@/lib/roles";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import Link from "next/link";
 import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/components/ui/tabs";
+import { ApprovalQueue } from "@/components/ApprovalQueue";
 import {
   ON_CHAIN_ENABLED,
   explorerTxUrl,
@@ -132,6 +133,41 @@ function useProjectAction(token: string | null) {
   });
 }
 
+// ─── Request Approval hook ──────────────────────────────────────────
+
+function useRequestApproval(token: string | null) {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: async ({
+      projectId,
+      action,
+      reason,
+    }: {
+      projectId: number;
+      action: "feature" | "unfeature" | "delete";
+      reason?: string;
+    }) => {
+      const res = await fetch(`/api/projects/${projectId}/request-approval`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${token}`,
+        },
+        body: JSON.stringify({ action, reason }),
+      });
+      if (!res.ok) {
+        const data = await res.json();
+        throw new Error(data.error || "Failed to submit approval request");
+      }
+    },
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ["approval-requests"] });
+    },
+  });
+}
+
+// ─── Promo Codes ──────────────────────────────────────────────────────
+
 interface PromoCode {
   id: number;
   code: string;
@@ -157,10 +193,129 @@ function useAdminPromoCodes(token: string | null) {
   });
 }
 
+// ─── Request Approval Dialog ──────────────────────────────────────────
+
+const ACTION_META: Record<string, { title: string; description: string; buttonLabel: string; buttonClass: string }> = {
+  feature: {
+    title: "Request: Mark as Featured",
+    description: "This will send a request for a second admin to confirm featuring this project. You cannot approve your own request.",
+    buttonLabel: "Submit Feature Request",
+    buttonClass: "bg-solar/15 hover:bg-solar/25 text-solar-bright border border-solar/20",
+  },
+  unfeature: {
+    title: "Request: Remove from Featured",
+    description: "This will send a request for a second admin to confirm unfeaturing this project.",
+    buttonLabel: "Submit Unfeature Request",
+    buttonClass: "bg-dust/30 hover:bg-dust/50 text-ash hover:text-moonlight border border-dust/20",
+  },
+  delete: {
+    title: "Request: Permanently Delete",
+    description: "Deletion is irreversible. A second admin must confirm before the project is removed.",
+    buttonLabel: "Submit Delete Request",
+    buttonClass: "bg-supernova/15 hover:bg-supernova/25 text-supernova border border-supernova/20",
+  },
+};
+
+function RequestApprovalDialog({
+  project,
+  action,
+  requestApproval,
+  triggerClassName,
+  triggerLabel,
+}: {
+  project: Project;
+  action: "feature" | "unfeature" | "delete";
+  requestApproval: ReturnType<typeof useRequestApproval>;
+  triggerClassName: string;
+  triggerLabel: string;
+}) {
+  const [reason, setReason] = useState("");
+  const [open, setOpen] = useState(false);
+  const [submitted, setSubmitted] = useState(false);
+  const meta = ACTION_META[action];
+
+  function handleSubmit() {
+    requestApproval.mutate(
+      { projectId: project.id, action, reason: reason || undefined },
+      {
+        onSuccess: () => {
+          setSubmitted(true);
+          setReason("");
+        },
+      }
+    );
+  }
+
+  function handleOpenChange(val: boolean) {
+    if (!val) setSubmitted(false);
+    setOpen(val);
+  }
+
+  return (
+    <AlertDialog open={open} onOpenChange={handleOpenChange}>
+      <AlertDialogTrigger asChild>
+        <button
+          disabled={requestApproval.isPending}
+          className={`${triggerClassName} font-medium text-xs px-3 py-1.5 rounded-lg transition-all disabled:opacity-50`}
+        >
+          {triggerLabel}
+        </button>
+      </AlertDialogTrigger>
+      <AlertDialogContent>
+        {submitted ? (
+          <>
+            <AlertDialogHeader>
+              <AlertDialogTitle>Request submitted</AlertDialogTitle>
+              <AlertDialogDescription>
+                Your request to {action} &ldquo;{project.name}&rdquo; has been queued. A second admin must review and approve it before the action executes.
+              </AlertDialogDescription>
+            </AlertDialogHeader>
+            <AlertDialogFooter>
+              <AlertDialogCancel>Close</AlertDialogCancel>
+            </AlertDialogFooter>
+          </>
+        ) : (
+          <>
+            <AlertDialogHeader>
+              <AlertDialogTitle>{meta.title}</AlertDialogTitle>
+              <AlertDialogDescription>{meta.description}</AlertDialogDescription>
+            </AlertDialogHeader>
+            <p className="text-sm text-moonlight">
+              Project: <span className="font-semibold">{project.name}</span>
+            </p>
+            <div className="space-y-2">
+              <label className="text-sm font-medium text-moonlight">
+                Reason <span className="text-ash">(optional)</span>
+              </label>
+              <Textarea
+                placeholder="Briefly explain why this action is needed..."
+                value={reason}
+                onChange={(e) => setReason(e.target.value)}
+                rows={2}
+              />
+            </div>
+            <AlertDialogFooter>
+              <AlertDialogCancel onClick={() => setReason("")}>Cancel</AlertDialogCancel>
+              <button
+                onClick={handleSubmit}
+                disabled={requestApproval.isPending}
+                className={`${meta.buttonClass} font-medium text-sm px-4 py-2 rounded-xl transition-all disabled:opacity-50`}
+              >
+                {requestApproval.isPending ? "Submitting..." : meta.buttonLabel}
+              </button>
+            </AlertDialogFooter>
+          </>
+        )}
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+}
+
+// ─── Promo Codes Tab ──────────────────────────────────────────────────
+
 function PromoCodesTab({ token }: { token: string | null }) {
   const qc = useQueryClient();
   const { data: promos = [], isLoading } = useAdminPromoCodes(token);
-  
   const [code, setCode] = useState("");
   const [percentOff, setPercentOff] = useState("");
   const [maxUses, setMaxUses] = useState("");
@@ -175,10 +330,7 @@ function PromoCodesTab({ token }: { token: string | null }) {
     try {
       const res = await fetch("/api/admin/promo-codes", {
         method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-          Authorization: `Bearer ${token}`,
-        },
+        headers: { "Content-Type": "application/json", Authorization: `Bearer ${token}` },
         body: JSON.stringify({
           code: code.trim().toUpperCase(),
           percent_off: Number(percentOff),
@@ -190,10 +342,7 @@ function PromoCodesTab({ token }: { token: string | null }) {
         const d = await res.json();
         throw new Error(d.error || "Failed to create promo code");
       }
-      setCode("");
-      setPercentOff("");
-      setMaxUses("");
-      setExpiresAt("");
+      setCode(""); setPercentOff(""); setMaxUses(""); setExpiresAt("");
       qc.invalidateQueries({ queryKey: ["admin-promo-codes"] });
     } catch (err) {
       setError(err instanceof Error ? err.message : "Error creating code");
@@ -223,59 +372,26 @@ function PromoCodesTab({ token }: { token: string | null }) {
         <form onSubmit={createPromo} className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-5 gap-4 items-end">
           <div>
             <label className="text-xs text-ash mb-1 block">Code *</label>
-            <input
-              type="text"
-              required
-              value={code}
-              onChange={(e) => setCode(e.target.value.toUpperCase())}
-              className="input-field w-full text-sm font-mono"
-              placeholder="e.g. HALFOFF"
-            />
+            <input type="text" required value={code} onChange={(e) => setCode(e.target.value.toUpperCase())} className="input-field w-full text-sm font-mono" placeholder="e.g. HALFOFF" />
           </div>
           <div>
             <label className="text-xs text-ash mb-1 block">% Off *</label>
-            <input
-              type="number"
-              required
-              min="1"
-              max="100"
-              value={percentOff}
-              onChange={(e) => setPercentOff(e.target.value)}
-              className="input-field w-full text-sm"
-              placeholder="e.g. 50"
-            />
+            <input type="number" required min="1" max="100" value={percentOff} onChange={(e) => setPercentOff(e.target.value)} className="input-field w-full text-sm" placeholder="e.g. 50" />
           </div>
           <div>
             <label className="text-xs text-ash mb-1 block">Max Uses (optional)</label>
-            <input
-              type="number"
-              min="1"
-              value={maxUses}
-              onChange={(e) => setMaxUses(e.target.value)}
-              className="input-field w-full text-sm"
-              placeholder="e.g. 100"
-            />
+            <input type="number" min="1" value={maxUses} onChange={(e) => setMaxUses(e.target.value)} className="input-field w-full text-sm" placeholder="e.g. 100" />
           </div>
           <div>
             <label className="text-xs text-ash mb-1 block">Expires (optional)</label>
-            <input
-              type="datetime-local"
-              value={expiresAt}
-              onChange={(e) => setExpiresAt(e.target.value)}
-              className="input-field w-full text-sm"
-            />
+            <input type="datetime-local" value={expiresAt} onChange={(e) => setExpiresAt(e.target.value)} className="input-field w-full text-sm" />
           </div>
-          <button
-            type="submit"
-            disabled={isSubmitting || !code || !percentOff}
-            className="btn-nova text-sm w-full h-[42px] disabled:opacity-50"
-          >
+          <button type="submit" disabled={isSubmitting || !code || !percentOff} className="btn-nova text-sm w-full h-[42px] disabled:opacity-50">
             {isSubmitting ? "Creating..." : "Create"}
           </button>
         </form>
         {error && <p className="text-supernova text-xs mt-3">{error}</p>}
       </div>
-
       <div className="glass rounded-2xl p-6">
         <h3 className="font-semibold text-starlight mb-4">Active Promo Codes</h3>
         {isLoading ? (
@@ -283,50 +399,25 @@ function PromoCodesTab({ token }: { token: string | null }) {
         ) : promos.length > 0 ? (
           <div className="space-y-3">
             {promos.map((promo) => (
-              <div
-                key={promo.id}
-                className="bg-stardust/30 border border-dust/20 rounded-xl px-4 py-3 flex items-center justify-between gap-4 flex-wrap hover:border-dust/40 transition-colors"
-              >
+              <div key={promo.id} className="bg-stardust/30 border border-dust/20 rounded-xl px-4 py-3 flex items-center justify-between gap-4 flex-wrap hover:border-dust/40 transition-colors">
                 <div>
                   <div className="flex items-center gap-2 mb-1">
-                    <span className="font-mono font-bold text-plasma-bright text-lg">
-                      {promo.code}
-                    </span>
-                    <span className="tag tag-solar text-xs font-semibold">
-                      {promo.percent_off}% OFF
-                    </span>
-                    {promo.expires_at && new Date(promo.expires_at) < new Date() && (
-                      <span className="tag tag-supernova text-xs">Expired</span>
-                    )}
-                    {promo.max_uses && promo.uses >= promo.max_uses && (
-                      <span className="tag tag-supernova text-xs">Depleted</span>
-                    )}
+                    <span className="font-mono font-bold text-plasma-bright text-lg">{promo.code}</span>
+                    <span className="tag tag-solar text-xs font-semibold">{promo.percent_off}% OFF</span>
+                    {promo.expires_at && new Date(promo.expires_at) < new Date() && <span className="tag tag-supernova text-xs">Expired</span>}
+                    {promo.max_uses && promo.uses >= promo.max_uses && <span className="tag tag-supernova text-xs">Depleted</span>}
                   </div>
                   <div className="flex items-center gap-4 text-xs text-ash">
-                    <span>
-                      Uses: <span className="text-moonlight">{promo.uses}</span>
-                      {promo.max_uses ? ` / ${promo.max_uses}` : " (Unlimited)"}
-                    </span>
-                    {promo.expires_at && (
-                      <span>
-                        Expires: <span className="text-moonlight">{new Date(promo.expires_at).toLocaleDateString()} {new Date(promo.expires_at).toLocaleTimeString()}</span>
-                      </span>
-                    )}
+                    <span>Uses: <span className="text-moonlight">{promo.uses}</span>{promo.max_uses ? ` / ${promo.max_uses}` : " (Unlimited)"}</span>
+                    {promo.expires_at && <span>Expires: <span className="text-moonlight">{new Date(promo.expires_at).toLocaleDateString()}</span></span>}
                   </div>
                 </div>
-                <button
-                  onClick={() => deletePromo(promo.id)}
-                  className="bg-supernova/10 hover:bg-supernova/20 text-supernova border border-supernova/20 text-xs px-4 py-2 rounded-lg transition-all font-medium shrink-0"
-                >
-                  Delete
-                </button>
+                <button onClick={() => deletePromo(promo.id)} className="bg-supernova/10 hover:bg-supernova/20 text-supernova border border-supernova/20 text-xs px-4 py-2 rounded-lg transition-all font-medium shrink-0">Delete</button>
               </div>
             ))}
           </div>
         ) : (
-          <div className="text-center py-6">
-            <p className="text-ash text-sm">No promo codes created yet.</p>
-          </div>
+          <div className="text-center py-6"><p className="text-ash text-sm">No promo codes created yet.</p></div>
         )}
       </div>
     </div>
@@ -336,30 +427,12 @@ function PromoCodesTab({ token }: { token: string | null }) {
 // ─── Reject Dialog ──────────────────────────────────────────────────
 
 const REJECT_REASON_TEMPLATES = [
-  {
-    label: "Not part of the Stellar Wave Program",
-    text: "This project does not appear to be part of the Stellar Wave Program.",
-  },
-  {
-    label: "Unverifiable on-chain account/contract ID",
-    text: "The Stellar account ID / Soroban contract ID provided could not be verified on-chain.",
-  },
-  {
-    label: "Description too short or not original",
-    text: "The description doesn't meet the minimum length, or appears to be copied rather than original.",
-  },
-  {
-    label: "Category/tags don't match the project",
-    text: "The category and/or tags don't accurately reflect what this project does.",
-  },
-  {
-    label: "Duplicate submission",
-    text: "This project has already been submitted.",
-  },
-  {
-    label: "Other / write a custom reason",
-    text: "",
-  },
+  { label: "Not part of the Stellar Wave Program", text: "This project does not appear to be part of the Stellar Wave Program." },
+  { label: "Unverifiable on-chain account/contract ID", text: "The Stellar account ID / Soroban contract ID provided could not be verified on-chain." },
+  { label: "Description too short or not original", text: "The description doesn't meet the minimum length, or appears to be copied rather than original." },
+  { label: "Category/tags don't match the project", text: "The category and/or tags don't accurately reflect what this project does." },
+  { label: "Duplicate submission", text: "This project has already been submitted." },
+  { label: "Other / write a custom reason", text: "" },
 ] as const;
 
 function RejectDialog({
@@ -375,76 +448,46 @@ function RejectDialog({
   const [template, setTemplate] = useState("");
   const [open, setOpen] = useState(false);
 
-  const reset = () => {
-    setReason("");
-    setTemplate("");
-  };
+  const reset = () => { setReason(""); setTemplate(""); };
 
   return (
     <AlertDialog open={open} onOpenChange={setOpen}>
       <AlertDialogTrigger asChild>
-        <button
-          disabled={isPending}
-          className="bg-supernova/15 hover:bg-supernova/25 text-supernova border border-supernova/20 font-medium text-sm px-4 py-2 rounded-xl transition-all disabled:opacity-50"
-        >
+        <button disabled={isPending} className="bg-supernova/15 hover:bg-supernova/25 text-supernova border border-supernova/20 font-medium text-sm px-4 py-2 rounded-xl transition-all disabled:opacity-50">
           Reject
         </button>
       </AlertDialogTrigger>
       <AlertDialogContent>
         <AlertDialogHeader>
-          <AlertDialogTitle>
-            Reject &ldquo;{project.name}&rdquo;?
-          </AlertDialogTitle>
+          <AlertDialogTitle>Reject &ldquo;{project.name}&rdquo;?</AlertDialogTitle>
           <AlertDialogDescription>
             This project will be moved to rejected status and won&apos;t appear in the public directory.
           </AlertDialogDescription>
         </AlertDialogHeader>
         <div className="space-y-4">
           <div className="space-y-2">
-            <label className="text-sm font-medium text-moonlight">
-              Template <span className="text-ash">(optional)</span>
-            </label>
-            <Select
-              value={template}
-              onValueChange={(value) => {
-                setTemplate(value);
-                const picked = REJECT_REASON_TEMPLATES.find((t) => t.label === value);
-                setReason(picked?.text ?? "");
-              }}
-            >
-              <SelectTrigger>
-                <SelectValue placeholder="Choose a reason template..." />
-              </SelectTrigger>
+            <label className="text-sm font-medium text-moonlight">Template <span className="text-ash">(optional)</span></label>
+            <Select value={template} onValueChange={(value) => {
+              setTemplate(value);
+              const picked = REJECT_REASON_TEMPLATES.find((t) => t.label === value);
+              setReason(picked?.text ?? "");
+            }}>
+              <SelectTrigger><SelectValue placeholder="Choose a reason template..." /></SelectTrigger>
               <SelectContent>
                 {REJECT_REASON_TEMPLATES.map((t) => (
-                  <SelectItem key={t.label} value={t.label}>
-                    {t.label}
-                  </SelectItem>
+                  <SelectItem key={t.label} value={t.label}>{t.label}</SelectItem>
                 ))}
               </SelectContent>
             </Select>
           </div>
           <div className="space-y-2">
-            <label className="text-sm font-medium text-moonlight">
-              Reason <span className="text-ash">(optional)</span>
-            </label>
-            <Textarea
-              placeholder="e.g. Not a Stellar Wave project, insufficient description..."
-              value={reason}
-              onChange={(e) => setReason(e.target.value)}
-              rows={3}
-            />
+            <label className="text-sm font-medium text-moonlight">Reason <span className="text-ash">(optional)</span></label>
+            <Textarea placeholder="e.g. Not a Stellar Wave project, insufficient description..." value={reason} onChange={(e) => setReason(e.target.value)} rows={3} />
           </div>
         </div>
         <AlertDialogFooter>
           <AlertDialogCancel onClick={reset}>Cancel</AlertDialogCancel>
-          <AlertDialogAction
-            onClick={() => {
-              onConfirm(reason);
-              reset();
-              setOpen(false);
-            }}
-          >
+          <AlertDialogAction onClick={() => { onConfirm(reason); reset(); setOpen(false); }}>
             Reject Project
           </AlertDialogAction>
         </AlertDialogFooter>
@@ -470,96 +513,26 @@ function DelistDialog({
   return (
     <AlertDialog open={open} onOpenChange={setOpen}>
       <AlertDialogTrigger asChild>
-        <button
-          disabled={isPending}
-          className="bg-supernova/10 hover:bg-supernova/20 text-supernova/80 hover:text-supernova border border-supernova/10 font-medium text-xs px-3 py-1.5 rounded-lg transition-all disabled:opacity-50"
-        >
+        <button disabled={isPending} className="bg-supernova/10 hover:bg-supernova/20 text-supernova/80 hover:text-supernova border border-supernova/10 font-medium text-xs px-3 py-1.5 rounded-lg transition-all disabled:opacity-50">
           Delist
         </button>
       </AlertDialogTrigger>
       <AlertDialogContent>
         <AlertDialogHeader>
-          <AlertDialogTitle>
-            Delist &ldquo;{project.name}&rdquo;?
-          </AlertDialogTitle>
+          <AlertDialogTitle>Delist &ldquo;{project.name}&rdquo;?</AlertDialogTitle>
           <AlertDialogDescription>
             This will remove the project from the public directory. It was previously{" "}
-            <span className="text-aurora-bright font-medium">
-              {project.status === "featured" ? "featured" : "approved"}
-            </span>
-            . You can re-approve it later.
+            <span className="text-aurora-bright font-medium">{project.status === "featured" ? "featured" : "approved"}</span>. You can re-approve it later.
           </AlertDialogDescription>
         </AlertDialogHeader>
         <div className="space-y-2">
-          <label className="text-sm font-medium text-moonlight">
-            Reason for delisting
-          </label>
-          <Textarea
-            placeholder="e.g. Mistakenly approved, project no longer active..."
-            value={reason}
-            onChange={(e) => setReason(e.target.value)}
-            rows={3}
-          />
+          <label className="text-sm font-medium text-moonlight">Reason for delisting</label>
+          <Textarea placeholder="e.g. Mistakenly approved, project no longer active..." value={reason} onChange={(e) => setReason(e.target.value)} rows={3} />
         </div>
         <AlertDialogFooter>
           <AlertDialogCancel onClick={() => setReason("")}>Cancel</AlertDialogCancel>
-          <AlertDialogAction
-            onClick={() => {
-              onConfirm(reason);
-              setReason("");
-              setOpen(false);
-            }}
-          >
+          <AlertDialogAction onClick={() => { onConfirm(reason); setReason(""); setOpen(false); }}>
             Delist Project
-          </AlertDialogAction>
-        </AlertDialogFooter>
-      </AlertDialogContent>
-    </AlertDialog>
-  );
-}
-
-// ─── Delete Dialog ──────────────────────────────────────────────────
-
-function DeleteDialog({
-  project,
-  onConfirm,
-  isPending,
-}: {
-  project: Project;
-  onConfirm: () => void;
-  isPending: boolean;
-}) {
-  const [open, setOpen] = useState(false);
-
-  return (
-    <AlertDialog open={open} onOpenChange={setOpen}>
-      <AlertDialogTrigger asChild>
-        <button
-          disabled={isPending}
-          className="text-supernova/50 hover:text-supernova text-xs underline-offset-2 hover:underline transition-all disabled:opacity-50"
-        >
-          Delete
-        </button>
-      </AlertDialogTrigger>
-      <AlertDialogContent>
-        <AlertDialogHeader>
-          <AlertDialogTitle>
-            Permanently delete &ldquo;{project.name}&rdquo;?
-          </AlertDialogTitle>
-          <AlertDialogDescription>
-            This action cannot be undone. The project and all its ratings will be permanently removed from the database.
-          </AlertDialogDescription>
-        </AlertDialogHeader>
-        <AlertDialogFooter>
-          <AlertDialogCancel>Cancel</AlertDialogCancel>
-          <AlertDialogAction
-            className="bg-supernova/20 hover:bg-supernova/40 border-supernova/30"
-            onClick={() => {
-              onConfirm();
-              setOpen(false);
-            }}
-          >
-            Delete Permanently
           </AlertDialogAction>
         </AlertDialogFooter>
       </AlertDialogContent>
@@ -578,11 +551,7 @@ function StatusBadge({ status, featured }: { status: string; featured?: number }
     delisted: "bg-dust/50 text-ash border border-dust/30",
   };
   const label = featured ? "featured" : status;
-  return (
-    <span className={`tag ${styles[label] || "tag-nova"}`}>
-      {label}
-    </span>
-  );
+  return <span className={`tag ${styles[label] || "tag-nova"}`}>{label}</span>;
 }
 
 // ─── Project card for pending queue ─────────────────────────────────
@@ -590,9 +559,11 @@ function StatusBadge({ status, featured }: { status: string; featured?: number }
 function PendingCard({
   project,
   action,
+  requestApproval,
 }: {
   project: Project;
   action: ReturnType<typeof useProjectAction>;
+  requestApproval: ReturnType<typeof useRequestApproval>;
 }) {
   const isLoading = action.isPending;
 
@@ -601,9 +572,7 @@ function PendingCard({
       <div className="flex flex-col lg:flex-row lg:items-start gap-4">
         <div className="flex-1 min-w-0">
           <div className="flex items-center gap-3 mb-2 flex-wrap">
-            <h3 className="font-semibold text-lg text-starlight">
-              {project.name}
-            </h3>
+            <h3 className="font-semibold text-lg text-starlight">{project.name}</h3>
             <span className="tag tag-nova text-xs">{project.category}</span>
             {project.stellar_network && (
               <span className={`tag text-xs ${project.stellar_network === "testnet" ? "bg-solar/10 text-solar-bright border border-solar/20" : "bg-aurora/10 text-aurora-bright border border-aurora/20"}`}>
@@ -611,93 +580,47 @@ function PendingCard({
               </span>
             )}
           </div>
-          <p className="text-sm text-moonlight/80 mb-3 line-clamp-2">
-            {project.description}
-          </p>
+          <p className="text-sm text-moonlight/80 mb-3 line-clamp-2">{project.description}</p>
           <div className="flex flex-wrap gap-x-4 gap-y-1 text-xs text-ash">
-            <span>
-              by <span className="text-moonlight">{project.username}</span>
-            </span>
+            <span>by <span className="text-moonlight">{project.username}</span></span>
             <span>{new Date(project.created_at).toLocaleDateString()}</span>
             {project.stellar_account_id && (
-              <span className="font-mono text-plasma-bright/60">
-                {project.stellar_account_id.slice(0, 10)}...
-              </span>
+              <span className="font-mono text-plasma-bright/60">{project.stellar_account_id.slice(0, 10)}...</span>
             )}
           </div>
-
-          {/* Research images — admin only */}
           {project.research_images && project.research_images.length > 0 && (
             <div className="mt-3 pt-3 border-t border-dust/20">
-              <p className="text-xs font-medium text-ash uppercase tracking-wider mb-2">
-                Research Images ({project.research_images.length})
-              </p>
+              <p className="text-xs font-medium text-ash uppercase tracking-wider mb-2">Research Images ({project.research_images.length})</p>
               <div className="flex gap-2 overflow-x-auto pb-2">
                 {project.research_images.map((url, i) => (
-                  <a
-                    key={i}
-                    href={url}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className="shrink-0 group"
-                  >
-                    <img
-                      src={url}
-                      alt={`Research ${i + 1}`}
-                      className="w-28 h-20 object-cover rounded-lg border border-dust/30 group-hover:border-nova/40 transition-all"
-                      loading="lazy"
-                    />
+                  <a key={i} href={url} target="_blank" rel="noopener noreferrer" className="shrink-0 group">
+                    <img src={url} alt={`Research ${i + 1}`} className="w-28 h-20 object-cover rounded-lg border border-dust/30 group-hover:border-nova/40 transition-all" loading="lazy" />
                   </a>
                 ))}
               </div>
             </div>
           )}
         </div>
-
         <div className="flex items-center gap-2 shrink-0 flex-wrap">
-          <Link
-            href={`/projects/${project.slug}`}
-            className="btn-ghost text-sm !py-2 !px-3"
-            target="_blank"
-          >
-            Preview
-          </Link>
+          <Link href={`/projects/${project.slug}`} className="btn-ghost text-sm !py-2 !px-3" target="_blank">Preview</Link>
           <button
             disabled={isLoading}
-            onClick={() =>
-              action.mutate({
-                projectId: project.id,
-                action: "approve",
-                body: { featured: false },
-              })
-            }
+            onClick={() => action.mutate({ projectId: project.id, action: "approve", body: { featured: false } })}
             className="bg-aurora/15 hover:bg-aurora/25 text-aurora-bright border border-aurora/20 font-medium text-sm px-4 py-2 rounded-xl transition-all disabled:opacity-50"
           >
             Approve
           </button>
-          <button
-            disabled={isLoading}
-            onClick={() =>
-              action.mutate({
-                projectId: project.id,
-                action: "approve",
-                body: { featured: true },
-              })
-            }
-            className="bg-solar/15 hover:bg-solar/25 text-solar-bright border border-solar/20 font-medium text-sm px-4 py-2 rounded-xl transition-all disabled:opacity-50"
-          >
-            Feature
-          </button>
+          <RequestApprovalDialog
+            project={project}
+            action="feature"
+            requestApproval={requestApproval}
+            triggerClassName="bg-solar/15 hover:bg-solar/25 text-solar-bright border border-solar/20 text-sm !px-4 !py-2"
+            triggerLabel="Feature"
+          />
           <RejectDialog
             project={project}
             isPending={isLoading}
-            onConfirm={(reason) =>
-              action.mutate({
-                projectId: project.id,
-                action: "reject",
-                body: { reason: reason || undefined },
-              })
-            }
+            onConfirm={(reason) => action.mutate({ projectId: project.id, action: "reject", body: { reason: reason || undefined } })}
           />
         </div>
       </div>
@@ -710,9 +633,11 @@ function PendingCard({
 function ProjectRow({
   project,
   action,
+  requestApproval,
 }: {
   project: Project;
   action: ReturnType<typeof useProjectAction>;
+  requestApproval: ReturnType<typeof useRequestApproval>;
 }) {
   const isLoading = action.isPending;
 
@@ -720,99 +645,58 @@ function ProjectRow({
     <div className="glass rounded-xl p-4 flex flex-col sm:flex-row sm:items-center gap-3 transition-all hover:border-dust/40">
       <div className="flex-1 min-w-0">
         <div className="flex items-center gap-2 mb-1 flex-wrap">
-          <Link
-            href={`/projects/${project.slug}`}
-            className="font-medium text-starlight hover:text-nova-bright transition-colors truncate"
-          >
-            {project.name}
-          </Link>
+          <Link href={`/projects/${project.slug}`} className="font-medium text-starlight hover:text-nova-bright transition-colors truncate">{project.name}</Link>
           <StatusBadge status={project.status} featured={project.featured} />
-          <span className="tag text-xs bg-stardust/50 text-ash border border-dust/20">
-            {project.category}
-          </span>
+          <span className="tag text-xs bg-stardust/50 text-ash border border-dust/20">{project.category}</span>
         </div>
         <div className="flex flex-wrap gap-x-4 gap-y-0.5 text-xs text-ash">
           <span>by {project.username}</span>
           <span>{new Date(project.created_at).toLocaleDateString()}</span>
-          {project.avg_rating != null && (
-            <span className="text-solar-bright">
-              {project.avg_rating.toFixed(1)} ({project.rating_count} ratings)
-            </span>
-          )}
-          {project.rejection_reason && (
-            <span className="text-supernova/70 italic truncate max-w-[200px]">
-              {project.rejection_reason}
-            </span>
-          )}
+          {project.avg_rating != null && <span className="text-solar-bright">{project.avg_rating.toFixed(1)} ({project.rating_count} ratings)</span>}
+          {project.rejection_reason && <span className="text-supernova/70 italic truncate max-w-[200px]">{project.rejection_reason}</span>}
         </div>
       </div>
-
       <div className="flex items-center gap-2 shrink-0 flex-wrap">
         {(project.status === "approved" || project.status === "featured") && (
           <DelistDialog
             project={project}
             isPending={isLoading}
-            onConfirm={(reason) =>
-              action.mutate({
-                projectId: project.id,
-                action: "delist",
-                body: { reason },
-              })
-            }
+            onConfirm={(reason) => action.mutate({ projectId: project.id, action: "delist", body: { reason } })}
           />
         )}
         {(project.status === "rejected" || project.status === "delisted") && (
           <button
             disabled={isLoading}
-            onClick={() =>
-              action.mutate({
-                projectId: project.id,
-                action: "approve",
-                body: { featured: false },
-              })
-            }
+            onClick={() => action.mutate({ projectId: project.id, action: "approve", body: { featured: false } })}
             className="bg-aurora/10 hover:bg-aurora/20 text-aurora-bright/80 hover:text-aurora-bright border border-aurora/10 font-medium text-xs px-3 py-1.5 rounded-lg transition-all disabled:opacity-50"
           >
             Re-approve
           </button>
         )}
-        {project.status !== "featured" &&
-          (project.status === "approved" || project.status === "featured") && (
-          <button
-            disabled={isLoading}
-            onClick={() =>
-              action.mutate({
-                projectId: project.id,
-                action: "approve",
-                body: { featured: true },
-              })
-            }
-            className="bg-solar/10 hover:bg-solar/20 text-solar-bright/80 hover:text-solar-bright border border-solar/10 font-medium text-xs px-3 py-1.5 rounded-lg transition-all disabled:opacity-50"
-          >
-            Feature
-          </button>
+        {project.status !== "featured" && (project.status === "approved" || project.status === "featured") && (
+          <RequestApprovalDialog
+            project={project}
+            action="feature"
+            requestApproval={requestApproval}
+            triggerClassName="bg-solar/10 hover:bg-solar/20 text-solar-bright/80 hover:text-solar-bright border border-solar/10"
+            triggerLabel="Feature"
+          />
         )}
         {project.featured === 1 && (
-          <button
-            disabled={isLoading}
-            onClick={() =>
-              action.mutate({
-                projectId: project.id,
-                action: "approve",
-                body: { featured: false },
-              })
-            }
-            className="bg-dust/30 hover:bg-dust/50 text-ash hover:text-moonlight border border-dust/20 font-medium text-xs px-3 py-1.5 rounded-lg transition-all disabled:opacity-50"
-          >
-            Unfeature
-          </button>
+          <RequestApprovalDialog
+            project={project}
+            action="unfeature"
+            requestApproval={requestApproval}
+            triggerClassName="bg-dust/30 hover:bg-dust/50 text-ash hover:text-moonlight border border-dust/20"
+            triggerLabel="Unfeature"
+          />
         )}
-        <DeleteDialog
+        <RequestApprovalDialog
           project={project}
-          isPending={isLoading}
-          onConfirm={() =>
-            action.mutate({ projectId: project.id, action: "delete" })
-          }
+          action="delete"
+          requestApproval={requestApproval}
+          triggerClassName="text-supernova/50 hover:text-supernova border-0 !px-2 underline-offset-2 hover:underline"
+          triggerLabel="Delete"
         />
       </div>
     </div>
@@ -824,9 +708,7 @@ function ProjectRow({
 function EmptyState({ icon, title, subtitle }: { icon: React.ReactNode; title: string; subtitle: string }) {
   return (
     <div className="glass rounded-2xl p-12 text-center">
-      <div className="w-16 h-16 mx-auto mb-4 rounded-2xl bg-stardust/50 flex items-center justify-center">
-        {icon}
-      </div>
+      <div className="w-16 h-16 mx-auto mb-4 rounded-2xl bg-stardust/50 flex items-center justify-center">{icon}</div>
       <h3 className="font-semibold text-lg text-moonlight mb-2">{title}</h3>
       <p className="text-ash">{subtitle}</p>
     </div>
@@ -838,9 +720,7 @@ function EmptyState({ icon, title, subtitle }: { icon: React.ReactNode; title: s
 function Skeletons({ count = 3 }: { count?: number }) {
   return (
     <div className="space-y-3">
-      {[...Array(count)].map((_, i) => (
-        <div key={i} className="skeleton h-20 rounded-xl" />
-      ))}
+      {[...Array(count)].map((_, i) => <div key={i} className="skeleton h-20 rounded-xl" />)}
     </div>
   );
 }
@@ -877,7 +757,6 @@ function ContractPanel({ adminAddress }: { adminAddress: string }) {
   const [txMsg, setTxMsg] = useState<{ text: string; hash?: string } | null>(null);
   const [busy, setBusy] = useState(false);
 
-  // Form fields
   const [newRatingFee, setNewRatingFee] = useState("");
   const [newRegFee, setNewRegFee] = useState("");
   const [newTreasury, setNewTreasury] = useState("");
@@ -892,12 +771,8 @@ function ContractPanel({ adminAddress }: { adminAddress: string }) {
     try {
       const [version, wasmVersion, admin, ratingFee, registrationFee, treasuryBalance] =
         await Promise.allSettled([
-          getContractVersion(),
-          getWasmVersion(),
-          getContractAdmin(),
-          getRatingFee(),
-          getRegistrationFee(),
-          getTreasuryBalance(),
+          getContractVersion(), getWasmVersion(), getContractAdmin(),
+          getRatingFee(), getRegistrationFee(), getTreasuryBalance(),
         ]);
       setInfo({
         version: version.status === "fulfilled" ? version.value : null,
@@ -912,13 +787,10 @@ function ContractPanel({ adminAddress }: { adminAddress: string }) {
     }
   }, []);
 
-  useEffect(() => {
-    if (ON_CHAIN_ENABLED) fetchInfo();
-  }, [fetchInfo]);
+  useEffect(() => { if (ON_CHAIN_ENABLED) fetchInfo(); }, [fetchInfo]);
 
   async function run(label: string, fn: () => Promise<string>) {
-    setBusy(true);
-    setTxMsg(null);
+    setBusy(true); setTxMsg(null);
     try {
       const hash = await fn();
       setTxMsg({ text: `${label} confirmed.`, hash });
@@ -934,56 +806,38 @@ function ContractPanel({ adminAddress }: { adminAddress: string }) {
       <div className="glass rounded-2xl p-12 text-center">
         <div className="w-16 h-16 mx-auto mb-4 rounded-2xl bg-stardust/50 flex items-center justify-center">
           <svg width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="var(--ash)" strokeWidth="1.5">
-            <path d="M12 2L2 7l10 5 10-5-10-5z" />
-            <path d="M2 17l10 5 10-5" />
-            <path d="M2 12l10 5 10-5" />
+            <path d="M12 2L2 7l10 5 10-5-10-5z" /><path d="M2 17l10 5 10-5" /><path d="M2 12l10 5 10-5" />
           </svg>
         </div>
         <h3 className="font-semibold text-lg text-moonlight mb-2">Contract not configured</h3>
-        <p className="text-ash text-sm">
-          Set <code className="text-plasma-bright font-mono">NEXT_PUBLIC_CONTRACT_ID</code> to enable on-chain operations.
-        </p>
+        <p className="text-ash text-sm">Set <code className="text-plasma-bright font-mono">NEXT_PUBLIC_CONTRACT_ID</code> to enable on-chain operations.</p>
       </div>
     );
   }
 
   return (
     <div className="space-y-6">
-      {/* Feedback banner */}
       {txMsg && (
         <div className={`rounded-xl px-4 py-3 text-sm flex items-center justify-between gap-4 ${txMsg.hash ? "bg-aurora/10 border border-aurora/20 text-aurora-bright" : "bg-supernova/10 border border-supernova/20 text-supernova"}`}>
           <span>{txMsg.text}</span>
           <div className="flex items-center gap-3 shrink-0">
-            {txMsg.hash && (
-              <a href={explorerTxUrl(txMsg.hash)} target="_blank" rel="noopener noreferrer" className="underline font-mono text-xs">
-                View tx
-              </a>
-            )}
+            {txMsg.hash && <a href={explorerTxUrl(txMsg.hash)} target="_blank" rel="noopener noreferrer" className="underline font-mono text-xs">View tx</a>}
             <button onClick={() => setTxMsg(null)} className="opacity-60 hover:opacity-100 transition-opacity">
-              <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
-                <line x1="18" y1="6" x2="6" y2="18" /><line x1="6" y1="6" x2="18" y2="18" />
-              </svg>
+              <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2"><line x1="18" y1="6" x2="6" y2="18" /><line x1="6" y1="6" x2="18" y2="18" /></svg>
             </button>
           </div>
         </div>
       )}
-
-      {/* Contract info */}
       <div className="glass rounded-2xl p-6">
         <div className="flex items-center justify-between mb-5">
           <h3 className="font-semibold text-starlight flex items-center gap-2">
             <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="var(--plasma-bright)" strokeWidth="2">
-              <path d="M12 2L2 7l10 5 10-5-10-5z" />
-              <path d="M2 17l10 5 10-5" /><path d="M2 12l10 5 10-5" />
+              <path d="M12 2L2 7l10 5 10-5-10-5z" /><path d="M2 17l10 5 10-5" /><path d="M2 12l10 5 10-5" />
             </svg>
             Contract State
           </h3>
-          <button
-            onClick={fetchInfo}
-            disabled={loadingInfo}
-            className="btn-ghost text-xs !py-1.5 !px-3 disabled:opacity-50"
-          >
-            {loadingInfo ? "Refreshing…" : "Refresh"}
+          <button onClick={fetchInfo} disabled={loadingInfo} className="btn-ghost text-xs !py-1.5 !px-3 disabled:opacity-50">
+            {loadingInfo ? "Refreshing..." : "Refresh"}
           </button>
         </div>
         <div className="grid grid-cols-2 sm:grid-cols-3 gap-3">
@@ -1007,173 +861,65 @@ function ContractPanel({ adminAddress }: { adminAddress: string }) {
           </div>
         )}
       </div>
-
       <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
-        {/* Set Rating Fee */}
         <div className="glass rounded-2xl p-6 space-y-3">
           <h4 className="font-medium text-starlight text-sm">Set Rating Fee</h4>
           <p className="text-xs text-ash">Current: <span className="text-solar-bright">{feeToUsdc(info.ratingFee)}</span></p>
           <div className="flex gap-2">
-            <input
-              type="number" min="0" step="0.000001" placeholder="e.g. 0.1"
-              value={newRatingFee}
-              onChange={(e) => setNewRatingFee(e.target.value)}
-              className="input-field flex-1 text-sm"
-            />
+            <input type="number" min="0" step="0.000001" placeholder="e.g. 0.1" value={newRatingFee} onChange={(e) => setNewRatingFee(e.target.value)} className="input-field flex-1 text-sm" />
             <span className="self-center text-xs text-ash">USDC</span>
           </div>
-          <button
-            disabled={busy || !newRatingFee}
-            onClick={() => run("Rating fee updated", () => setRatingFeeOnChain(adminAddress, usdcToStroops(newRatingFee)))}
-            className="btn-nova text-sm w-full disabled:opacity-50"
-          >
-            Update
-          </button>
+          <button disabled={busy || !newRatingFee} onClick={() => run("Rating fee updated", () => setRatingFeeOnChain(adminAddress, usdcToStroops(newRatingFee)))} className="btn-nova text-sm w-full disabled:opacity-50">Update</button>
         </div>
-
-        {/* Set Registration Fee */}
         <div className="glass rounded-2xl p-6 space-y-3">
           <h4 className="font-medium text-starlight text-sm">Set Registration Fee</h4>
           <p className="text-xs text-ash">Current: <span className="text-solar-bright">{feeToUsdc(info.registrationFee)}</span></p>
           <div className="flex gap-2">
-            <input
-              type="number" min="0" step="0.000001" placeholder="e.g. 5.0"
-              value={newRegFee}
-              onChange={(e) => setNewRegFee(e.target.value)}
-              className="input-field flex-1 text-sm"
-            />
+            <input type="number" min="0" step="0.000001" placeholder="e.g. 5.0" value={newRegFee} onChange={(e) => setNewRegFee(e.target.value)} className="input-field flex-1 text-sm" />
             <span className="self-center text-xs text-ash">USDC</span>
           </div>
-          <button
-            disabled={busy || !newRegFee}
-            onClick={() => run("Registration fee updated", () => setRegistrationFeeOnChain(adminAddress, usdcToStroops(newRegFee)))}
-            className="btn-nova text-sm w-full disabled:opacity-50"
-          >
-            Update
-          </button>
+          <button disabled={busy || !newRegFee} onClick={() => run("Registration fee updated", () => setRegistrationFeeOnChain(adminAddress, usdcToStroops(newRegFee)))} className="btn-nova text-sm w-full disabled:opacity-50">Update</button>
         </div>
-
-        {/* Set Treasury */}
         <div className="glass rounded-2xl p-6 space-y-3">
           <h4 className="font-medium text-starlight text-sm">Set Treasury Address</h4>
-          <input
-            type="text" placeholder="G... address"
-            value={newTreasury}
-            onChange={(e) => setNewTreasury(e.target.value)}
-            className="input-field text-sm font-mono"
-          />
-          <button
-            disabled={busy || !newTreasury}
-            onClick={() => run("Treasury updated", () => setTreasuryOnChain(adminAddress, newTreasury))}
-            className="btn-nova text-sm w-full disabled:opacity-50"
-          >
-            Update Treasury
-          </button>
+          <input type="text" placeholder="G... address" value={newTreasury} onChange={(e) => setNewTreasury(e.target.value)} className="input-field text-sm font-mono" />
+          <button disabled={busy || !newTreasury} onClick={() => run("Treasury updated", () => setTreasuryOnChain(adminAddress, newTreasury))} className="btn-nova text-sm w-full disabled:opacity-50">Update Treasury</button>
         </div>
-
-        {/* Withdraw Fees */}
         <div className="glass rounded-2xl p-6 space-y-3">
           <h4 className="font-medium text-starlight text-sm">Withdraw Fees</h4>
-          <p className="text-xs text-ash">
-            Collected: <span className="text-aurora-bright font-semibold">{feeToUsdc(info.treasuryBalance)}</span>
-          </p>
+          <p className="text-xs text-ash">Collected: <span className="text-aurora-bright font-semibold">{feeToUsdc(info.treasuryBalance)}</span></p>
           <p className="text-xs text-ash/70">Sends all collected fees to the treasury address.</p>
-          <button
-            disabled={busy || !info.treasuryBalance || info.treasuryBalance <= BigInt(0)}
-            onClick={() => run("Fees withdrawn", () => withdrawFeesOnChain(adminAddress))}
-            className="btn-nova text-sm w-full disabled:opacity-50"
-          >
-            Withdraw to Treasury
-          </button>
+          <button disabled={busy || !info.treasuryBalance || info.treasuryBalance <= BigInt(0)} onClick={() => run("Fees withdrawn", () => withdrawFeesOnChain(adminAddress))} className="btn-nova text-sm w-full disabled:opacity-50">Withdraw to Treasury</button>
         </div>
-
-        {/* Register Project */}
         <div className="glass rounded-2xl p-6 space-y-3">
           <h4 className="font-medium text-starlight text-sm">Register Project On-Chain</h4>
-          <input
-            type="text" placeholder="Project ID (symbol, e.g. my_proj)"
-            value={regProjectId}
-            onChange={(e) => setRegProjectId(e.target.value)}
-            className="input-field text-sm font-mono"
-          />
-          <input
-            type="text" placeholder="Project account (G... address)"
-            value={regAccountId}
-            onChange={(e) => setRegAccountId(e.target.value)}
-            className="input-field text-sm font-mono"
-          />
+          <input type="text" placeholder="Project ID (symbol, e.g. my_proj)" value={regProjectId} onChange={(e) => setRegProjectId(e.target.value)} className="input-field text-sm font-mono" />
+          <input type="text" placeholder="Project account (G... address)" value={regAccountId} onChange={(e) => setRegAccountId(e.target.value)} className="input-field text-sm font-mono" />
           <p className="text-xs text-ash/70">Registration fee is paid from the admin wallet.</p>
-          <button
-            disabled={busy || !regProjectId || !regAccountId}
-            onClick={() => run("Project registered", () => registerProjectOnChain(adminAddress, regProjectId, regAccountId))}
-            className="btn-nova text-sm w-full disabled:opacity-50"
-          >
-            Register
-          </button>
+          <button disabled={busy || !regProjectId || !regAccountId} onClick={() => run("Project registered", () => registerProjectOnChain(adminAddress, regProjectId, regAccountId))} className="btn-nova text-sm w-full disabled:opacity-50">Register</button>
         </div>
-
-        {/* Remove Project */}
         <div className="glass rounded-2xl p-6 space-y-3">
           <h4 className="font-medium text-starlight text-sm">Remove Project From Chain</h4>
-          <input
-            type="text" placeholder="Project ID (symbol)"
-            value={removeProjectId}
-            onChange={(e) => setRemoveProjectId(e.target.value)}
-            className="input-field text-sm font-mono"
-          />
+          <input type="text" placeholder="Project ID (symbol)" value={removeProjectId} onChange={(e) => setRemoveProjectId(e.target.value)} className="input-field text-sm font-mono" />
           <p className="text-xs text-ash/70">No fee refund. Ratings remain on-chain.</p>
-          <button
-            disabled={busy || !removeProjectId}
-            onClick={() => run("Project removed", () => removeProjectOnChain(adminAddress, removeProjectId))}
-            className="bg-supernova/15 hover:bg-supernova/25 text-supernova border border-supernova/20 font-medium text-sm px-4 py-2 rounded-xl transition-all w-full disabled:opacity-50"
-          >
-            Remove
-          </button>
+          <button disabled={busy || !removeProjectId} onClick={() => run("Project removed", () => removeProjectOnChain(adminAddress, removeProjectId))} className="bg-supernova/15 hover:bg-supernova/25 text-supernova border border-supernova/20 font-medium text-sm px-4 py-2 rounded-xl transition-all w-full disabled:opacity-50">Remove</button>
         </div>
-
-        {/* Upgrade Version */}
         <div className="glass rounded-2xl p-6 space-y-3">
           <h4 className="font-medium text-starlight text-sm">Upgrade Version String</h4>
           <p className="text-xs text-ash">Current: <span className="text-moonlight font-mono">{info.version ?? "—"}</span></p>
-          <input
-            type="text" placeholder="e.g. 1.2.0"
-            value={newVersion}
-            onChange={(e) => setNewVersion(e.target.value)}
-            className="input-field text-sm font-mono"
-          />
-          <button
-            disabled={busy || !newVersion}
-            onClick={() => run("Version updated", () => upgradeVersionOnChain(adminAddress, newVersion))}
-            className="btn-nova text-sm w-full disabled:opacity-50"
-          >
-            Update Version
-          </button>
+          <input type="text" placeholder="e.g. 1.2.0" value={newVersion} onChange={(e) => setNewVersion(e.target.value)} className="input-field text-sm font-mono" />
+          <button disabled={busy || !newVersion} onClick={() => run("Version updated", () => upgradeVersionOnChain(adminAddress, newVersion))} className="btn-nova text-sm w-full disabled:opacity-50">Update Version</button>
         </div>
-
-        {/* Transfer Admin */}
         <div className="glass rounded-2xl p-6 space-y-3">
           <h4 className="font-medium text-starlight text-sm">Transfer Admin</h4>
-          <p className="text-xs text-supernova/80 font-medium">⚠ Irreversible — double-check the address.</p>
-          <input
-            type="text" placeholder="New admin G... address"
-            value={newAdmin}
-            onChange={(e) => setNewAdmin(e.target.value)}
-            className="input-field text-sm font-mono"
-          />
-          <button
-            disabled={busy || !newAdmin}
-            onClick={() => run("Admin transferred", () => transferAdminOnChain(adminAddress, newAdmin))}
-            className="bg-supernova/15 hover:bg-supernova/25 text-supernova border border-supernova/20 font-medium text-sm px-4 py-2 rounded-xl transition-all w-full disabled:opacity-50"
-          >
-            Transfer Admin Rights
-          </button>
+          <p className="text-xs text-supernova/80 font-medium">Warning: Irreversible — double-check the address.</p>
+          <input type="text" placeholder="New admin G... address" value={newAdmin} onChange={(e) => setNewAdmin(e.target.value)} className="input-field text-sm font-mono" />
+          <button disabled={busy || !newAdmin} onClick={() => run("Admin transferred", () => transferAdminOnChain(adminAddress, newAdmin))} className="bg-supernova/15 hover:bg-supernova/25 text-supernova border border-supernova/20 font-medium text-sm px-4 py-2 rounded-xl transition-all w-full disabled:opacity-50">Transfer Admin Rights</button>
         </div>
       </div>
     </div>
   );
 }
-
-// ─── Main page ──────────────────────────────────────────────────────
 
 // ─── Search filter helper ──────────────────────────────────────────
 
@@ -1190,9 +936,12 @@ function filterProjects(projects: Project[], query: string): Project[] {
   );
 }
 
+// ─── Main page ──────────────────────────────────────────────────────
+
 export default function AdminPage() {
   const { user, token } = useAuth();
   const action = useProjectAction(token);
+  const requestApproval = useRequestApproval(token);
   const [search, setSearch] = useState("");
 
   const { data: pending = [], isLoading: pendingLoading } = usePendingProjects(token);
@@ -1232,19 +981,12 @@ export default function AdminPage() {
           <div className="flex items-center gap-3">
             <div className="w-10 h-10 rounded-xl bg-gradient-to-br from-solar/30 to-nova/30 border border-solar/20 flex items-center justify-center">
               <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="var(--solar-bright)" strokeWidth="2">
-                <path d="M12 2L2 7l10 5 10-5-10-5z" />
-                <path d="M2 17l10 5 10-5" />
-                <path d="M2 12l10 5 10-5" />
+                <path d="M12 2L2 7l10 5 10-5-10-5z" /><path d="M2 17l10 5 10-5" /><path d="M2 12l10 5 10-5" />
               </svg>
             </div>
             <h1 className="font-display font-bold text-3xl text-starlight">Admin Dashboard</h1>
           </div>
-          <a
-            href="https://github.com/samieazubike/stellar-wave-hub/blob/main/docs/MAINTAINERS.md"
-            target="_blank"
-            rel="noopener noreferrer"
-            className="btn-ghost text-sm !py-2 !px-3"
-          >
+          <a href="https://github.com/samieazubike/stellar-wave-hub/blob/main/docs/MAINTAINERS.md" target="_blank" rel="noopener noreferrer" className="btn-ghost text-sm !py-2 !px-3">
             Maintainer Guide
           </a>
         </div>
@@ -1254,17 +996,8 @@ export default function AdminPage() {
       {/* Search */}
       <div className="mb-6 animate-in animate-in-delay-1">
         <div className="relative max-w-md">
-          <svg
-            className="absolute left-3 top-1/2 -translate-y-1/2 text-ash pointer-events-none"
-            width="16"
-            height="16"
-            viewBox="0 0 24 24"
-            fill="none"
-            stroke="currentColor"
-            strokeWidth="2"
-          >
-            <circle cx="11" cy="11" r="8" />
-            <line x1="21" y1="21" x2="16.65" y2="16.65" />
+          <svg className="absolute left-3 top-1/2 -translate-y-1/2 text-ash pointer-events-none" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+            <circle cx="11" cy="11" r="8" /><line x1="21" y1="21" x2="16.65" y2="16.65" />
           </svg>
           <input
             type="text"
@@ -1274,13 +1007,9 @@ export default function AdminPage() {
             className="w-full pl-10 pr-4 py-2.5 bg-stardust/50 border border-dust/30 rounded-xl text-sm text-moonlight placeholder:text-ash/60 focus:outline-none focus:border-nova/40 focus:ring-1 focus:ring-nova/20 transition-all"
           />
           {search && (
-            <button
-              onClick={() => setSearch("")}
-              className="absolute right-3 top-1/2 -translate-y-1/2 text-ash hover:text-moonlight transition-colors"
-            >
+            <button onClick={() => setSearch("")} className="absolute right-3 top-1/2 -translate-y-1/2 text-ash hover:text-moonlight transition-colors">
               <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
-                <line x1="18" y1="6" x2="6" y2="18" />
-                <line x1="6" y1="6" x2="18" y2="18" />
+                <line x1="18" y1="6" x2="6" y2="18" /><line x1="6" y1="6" x2="18" y2="18" />
               </svg>
             </button>
           )}
@@ -1289,189 +1018,105 @@ export default function AdminPage() {
 
       {/* Stats grid */}
       <div className="grid grid-cols-2 sm:grid-cols-4 gap-3 mb-8 animate-in animate-in-delay-2">
-        <div className="glass rounded-2xl p-5">
-          <p className="text-2xl font-bold text-solar-bright">{pending.length}</p>
-          <p className="text-xs text-ash mt-0.5 uppercase tracking-wider">Pending</p>
-        </div>
-        <div className="glass rounded-2xl p-5">
-          <p className="text-2xl font-bold text-aurora-bright">{approved.length}</p>
-          <p className="text-xs text-ash mt-0.5 uppercase tracking-wider">Approved</p>
-        </div>
-        <div className="glass rounded-2xl p-5">
-          <p className="text-2xl font-bold text-nova-bright">{featured.length}</p>
-          <p className="text-xs text-ash mt-0.5 uppercase tracking-wider">Featured</p>
-        </div>
-        <div className="glass rounded-2xl p-5">
-          <p className="text-2xl font-bold text-plasma-bright">{all.length}</p>
-          <p className="text-xs text-ash mt-0.5 uppercase tracking-wider">Total</p>
-        </div>
+        <div className="glass rounded-2xl p-5"><p className="text-2xl font-bold text-solar-bright">{pending.length}</p><p className="text-xs text-ash mt-0.5 uppercase tracking-wider">Pending</p></div>
+        <div className="glass rounded-2xl p-5"><p className="text-2xl font-bold text-aurora-bright">{approved.length}</p><p className="text-xs text-ash mt-0.5 uppercase tracking-wider">Approved</p></div>
+        <div className="glass rounded-2xl p-5"><p className="text-2xl font-bold text-nova-bright">{featured.length}</p><p className="text-xs text-ash mt-0.5 uppercase tracking-wider">Featured</p></div>
+        <div className="glass rounded-2xl p-5"><p className="text-2xl font-bold text-plasma-bright">{all.length}</p><p className="text-xs text-ash mt-0.5 uppercase tracking-wider">Total</p></div>
       </div>
 
-      {/* Mutation feedback */}
       {action.isError && (
         <div className="bg-supernova/10 border border-supernova/20 text-supernova rounded-xl px-4 py-3 text-sm mb-6 animate-in">
           {action.error.message}
         </div>
       )}
-      
+
       {/* Tabs */}
       <div className="animate-in animate-in-delay-3">
         <Tabs defaultValue="pending">
           <TabsList className="flex-wrap">
             <TabsTrigger value="pending">
               Pending
-              {filteredPending.length > 0 && (
-                <span className="ml-2 bg-solar/20 text-solar-bright text-xs px-2 py-0.5 rounded-md">
-                  {filteredPending.length}
-                </span>
-              )}
+              {filteredPending.length > 0 && <span className="ml-2 bg-solar/20 text-solar-bright text-xs px-2 py-0.5 rounded-md">{filteredPending.length}</span>}
             </TabsTrigger>
             <TabsTrigger value="approved">Approved</TabsTrigger>
             <TabsTrigger value="featured">Featured</TabsTrigger>
             <TabsTrigger value="rejected">
               Rejected / Delisted
-              {rejectedCount > 0 && (
-                <span className="ml-2 bg-supernova/15 text-supernova/80 text-xs px-2 py-0.5 rounded-md">
-                  {rejectedCount}
-                </span>
-              )}
+              {rejectedCount > 0 && <span className="ml-2 bg-supernova/15 text-supernova/80 text-xs px-2 py-0.5 rounded-md">{rejectedCount}</span>}
             </TabsTrigger>
             <TabsTrigger value="all">All Projects</TabsTrigger>
+            <TabsTrigger value="approvals">Approvals</TabsTrigger>
             <TabsTrigger value="contract">
               Contract
-              {ON_CHAIN_ENABLED && (
-                <span className="ml-2 bg-plasma/15 text-plasma-bright text-xs px-2 py-0.5 rounded-md">
-                  on-chain
-                </span>
-              )}
+              {ON_CHAIN_ENABLED && <span className="ml-2 bg-plasma/15 text-plasma-bright text-xs px-2 py-0.5 rounded-md">on-chain</span>}
             </TabsTrigger>
             <TabsTrigger value="promos">Promo Codes</TabsTrigger>
           </TabsList>
 
-          {/* ── Pending tab ── */}
+          {/* Pending */}
           <TabsContent value="pending">
-            {pendingLoading ? (
-              <Skeletons />
-            ) : filteredPending.length > 0 ? (
+            {pendingLoading ? <Skeletons /> : filteredPending.length > 0 ? (
               <div className="space-y-4">
-                {filteredPending.map((p) => (
-                  <PendingCard key={p.id} project={p} action={action} />
-                ))}
+                {filteredPending.map((p) => <PendingCard key={p.id} project={p} action={action} requestApproval={requestApproval} />)}
               </div>
             ) : (
-              <EmptyState
-                icon={
-                  <svg width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="var(--aurora)" strokeWidth="1.5">
-                    <polyline points="20 6 9 17 4 12" />
-                  </svg>
-                }
-                title="All caught up!"
-                subtitle="No projects pending review"
-              />
+              <EmptyState icon={<svg width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="var(--aurora)" strokeWidth="1.5"><polyline points="20 6 9 17 4 12" /></svg>} title="All caught up!" subtitle="No projects pending review" />
             )}
           </TabsContent>
 
-          {/* ── Approved tab ── */}
+          {/* Approved */}
           <TabsContent value="approved">
-            {approvedLoading ? (
-              <Skeletons />
-            ) : filteredApproved.length > 0 ? (
+            {approvedLoading ? <Skeletons /> : filteredApproved.length > 0 ? (
               <div className="space-y-2">
-                {filteredApproved.map((p) => (
-                  <ProjectRow key={p.id} project={p} action={action} />
-                ))}
+                {filteredApproved.map((p) => <ProjectRow key={p.id} project={p} action={action} requestApproval={requestApproval} />)}
               </div>
             ) : (
-              <EmptyState
-                icon={
-                  <svg width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="var(--ash)" strokeWidth="1.5">
-                    <circle cx="12" cy="12" r="10" />
-                    <line x1="12" y1="8" x2="12" y2="12" />
-                    <line x1="12" y1="16" x2="12.01" y2="16" />
-                  </svg>
-                }
-                title="No approved projects"
-                subtitle="Approved projects will appear here"
-              />
+              <EmptyState icon={<svg width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="var(--ash)" strokeWidth="1.5"><circle cx="12" cy="12" r="10" /><line x1="12" y1="8" x2="12" y2="12" /><line x1="12" y1="16" x2="12.01" y2="16" /></svg>} title="No approved projects" subtitle="Approved projects will appear here" />
             )}
           </TabsContent>
 
-          {/* ── Featured tab ── */}
+          {/* Featured */}
           <TabsContent value="featured">
-            {featuredLoading ? (
-              <Skeletons />
-            ) : filteredFeatured.length > 0 ? (
+            {featuredLoading ? <Skeletons /> : filteredFeatured.length > 0 ? (
               <div className="space-y-2">
-                {filteredFeatured.map((p) => (
-                  <ProjectRow key={p.id} project={p} action={action} />
-                ))}
+                {filteredFeatured.map((p) => <ProjectRow key={p.id} project={p} action={action} requestApproval={requestApproval} />)}
               </div>
             ) : (
-              <EmptyState
-                icon={
-                  <svg width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="var(--solar)" strokeWidth="1.5">
-                    <polygon points="12 2 15.09 8.26 22 9.27 17 14.14 18.18 21.02 12 17.77 5.82 21.02 7 14.14 2 9.27 8.91 8.26 12 2" />
-                  </svg>
-                }
-                title="No featured projects"
-                subtitle="Feature projects to highlight them in the directory"
-              />
+              <EmptyState icon={<svg width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="var(--solar)" strokeWidth="1.5"><polygon points="12 2 15.09 8.26 22 9.27 17 14.14 18.18 21.02 12 17.77 5.82 21.02 7 14.14 2 9.27 8.91 8.26 12 2" /></svg>} title="No featured projects" subtitle="Feature projects to highlight them in the directory" />
             )}
           </TabsContent>
 
-          {/* ── Rejected / Delisted tab ── */}
+          {/* Rejected / Delisted */}
           <TabsContent value="rejected">
-            {allLoading ? (
-              <Skeletons />
-            ) : rejectedCount > 0 ? (
+            {allLoading ? <Skeletons /> : rejectedCount > 0 ? (
               <div className="space-y-2">
-                {filteredAll
-                  .filter((p) => p.status === "rejected" || p.status === "delisted")
-                  .map((p) => (
-                    <ProjectRow key={p.id} project={p} action={action} />
-                  ))}
+                {filteredAll.filter((p) => p.status === "rejected" || p.status === "delisted").map((p) => <ProjectRow key={p.id} project={p} action={action} requestApproval={requestApproval} />)}
               </div>
             ) : (
-              <EmptyState
-                icon={
-                  <svg width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="var(--ash)" strokeWidth="1.5">
-                    <circle cx="12" cy="12" r="10" />
-                    <line x1="15" y1="9" x2="9" y2="15" />
-                    <line x1="9" y1="9" x2="15" y2="15" />
-                  </svg>
-                }
-                title="No rejected projects"
-                subtitle="Rejected and delisted projects will appear here"
-              />
+              <EmptyState icon={<svg width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="var(--ash)" strokeWidth="1.5"><circle cx="12" cy="12" r="10" /><line x1="15" y1="9" x2="9" y2="15" /><line x1="9" y1="9" x2="15" y2="15" /></svg>} title="No rejected projects" subtitle="Rejected and delisted projects will appear here" />
             )}
           </TabsContent>
 
-          {/* ── All projects tab ── */}
+          {/* All projects */}
           <TabsContent value="all">
-            {allLoading ? (
-              <Skeletons count={5} />
-            ) : filteredAll.length > 0 ? (
+            {allLoading ? <Skeletons count={5} /> : filteredAll.length > 0 ? (
               <div className="space-y-2">
-                {filteredAll.map((p) => (
-                  <ProjectRow key={p.id} project={p} action={action} />
-                ))}
+                {filteredAll.map((p) => <ProjectRow key={p.id} project={p} action={action} requestApproval={requestApproval} />)}
               </div>
             ) : (
-              <EmptyState
-                icon={
-                  <svg width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="var(--ash)" strokeWidth="1.5">
-                    <rect x="3" y="3" width="18" height="18" rx="2" />
-                    <line x1="3" y1="9" x2="21" y2="9" />
-                    <line x1="9" y1="21" x2="9" y2="9" />
-                  </svg>
-                }
-                title="No projects yet"
-                subtitle="Projects will appear here once submitted"
-              />
+              <EmptyState icon={<svg width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="var(--ash)" strokeWidth="1.5"><rect x="3" y="3" width="18" height="18" rx="2" /><line x1="3" y1="9" x2="21" y2="9" /><line x1="9" y1="21" x2="9" y2="9" /></svg>} title="No projects yet" subtitle="Projects will appear here once submitted" />
             )}
           </TabsContent>
 
-          {/* ── Contract tab ── */}
+          {/* Approvals */}
+          <TabsContent value="approvals">
+            <div className="mb-4 glass rounded-xl px-4 py-3 text-sm text-ash border border-dust/20">
+              Sensitive actions (feature, unfeature, delete) require a second admin to confirm. The admin who submitted the request cannot approve it themselves.
+            </div>
+            <ApprovalQueue token={token} currentUserId={user.id} />
+          </TabsContent>
+
+          {/* Contract */}
           <TabsContent value="contract">
             {user?.stellar_address ? (
               <ContractPanel adminAddress={user.stellar_address} />
@@ -1483,14 +1128,13 @@ export default function AdminPage() {
                   </svg>
                 </div>
                 <h3 className="font-semibold text-lg text-moonlight mb-2">Stellar wallet required</h3>
-                <p className="text-ash text-sm mb-4">
-                  Link a Stellar wallet in your profile to manage the registry contract.
-                </p>
+                <p className="text-ash text-sm mb-4">Link a Stellar wallet in your profile to manage the registry contract.</p>
                 <Link href="/profile" className="btn-ghost inline-flex text-sm">Go to Profile</Link>
               </div>
             )}
           </TabsContent>
 
+          {/* Promo Codes */}
           <TabsContent value="promos">
             <PromoCodesTab token={token} />
           </TabsContent>

--- a/web/src/app/api/approval-requests/[requestId]/approve/route.ts
+++ b/web/src/app/api/approval-requests/[requestId]/approve/route.ts
@@ -1,0 +1,80 @@
+import { approvalRequestsCol, projectsCol, ratingsCol } from "@/lib/db";
+import { getAuthUser } from "@/lib/auth";
+import { parseJsonBody } from "@/lib/validation/parse-body";
+import { reviewApprovalSchema } from "@/lib/validation/schemas/approval";
+export const dynamic = "force-dynamic";
+
+export async function PUT(
+  request: Request,
+  { params }: { params: Promise<{ requestId: string }> }
+) {
+  const auth = getAuthUser(request);
+  if (!auth || auth.role !== "admin") {
+    return Response.json({ error: "Forbidden" }, { status: 403 });
+  }
+
+  const { requestId } = await params;
+  const reqRef = approvalRequestsCol.ref.doc(requestId);
+  const reqDoc = await reqRef.get();
+
+  if (!reqDoc.exists) {
+    return Response.json({ error: "Approval request not found" }, { status: 404 });
+  }
+
+  const approvalData = reqDoc.data()!;
+
+  if (approvalData.status !== "pending") {
+    return Response.json({ error: "Request has already been reviewed" }, { status: 409 });
+  }
+
+  // Core rule: the approver must be a different admin than the requester
+  if (approvalData.requested_by === auth.userId) {
+    return Response.json(
+      { error: "You cannot approve your own request. A second admin must confirm this action." },
+      { status: 403 }
+    );
+  }
+
+  const parsed = await parseJsonBody(request, reviewApprovalSchema);
+  if (!parsed.success) return parsed.response;
+
+  try {
+    const now = new Date().toISOString();
+    const projectRef = projectsCol.ref.doc(String(approvalData.project_id));
+    const projectDoc = await projectRef.get();
+
+    if (!projectDoc.exists) {
+      return Response.json({ error: "Project not found" }, { status: 404 });
+    }
+
+    // Execute the actual sensitive action
+    const actionType = approvalData.action_type as string;
+    if (actionType === "feature") {
+      await projectRef.update({ status: "featured", featured: 1, updated_at: now });
+    } else if (actionType === "unfeature") {
+      await projectRef.update({ status: "approved", featured: 0, updated_at: now });
+    } else if (actionType === "delete") {
+      const rSnap = await ratingsCol.ref
+        .where("project_id", "==", Number(approvalData.project_id))
+        .get();
+      const batch = projectsCol.ref.firestore.batch();
+      rSnap.docs.forEach((d) => batch.delete(d.ref));
+      batch.delete(projectRef);
+      await batch.commit();
+    }
+
+    // Mark request as approved
+    await reqRef.update({
+      status: "approved",
+      reviewer_id: auth.userId,
+      reviewer_note: parsed.data.note || null,
+      reviewed_at: now,
+      updated_at: now,
+    });
+
+    return Response.json({ message: "Action approved and executed" });
+  } catch (err) {
+    console.error("Approve approval request error:", err);
+    return Response.json({ error: "Internal server error" }, { status: 500 });
+  }
+}

--- a/web/src/app/api/approval-requests/[requestId]/reject/route.ts
+++ b/web/src/app/api/approval-requests/[requestId]/reject/route.ts
@@ -1,0 +1,56 @@
+import { approvalRequestsCol } from "@/lib/db";
+import { getAuthUser } from "@/lib/auth";
+import { parseJsonBody } from "@/lib/validation/parse-body";
+import { rejectApprovalSchema } from "@/lib/validation/schemas/approval";
+export const dynamic = "force-dynamic";
+
+export async function PUT(
+  request: Request,
+  { params }: { params: Promise<{ requestId: string }> }
+) {
+  const auth = getAuthUser(request);
+  if (!auth || auth.role !== "admin") {
+    return Response.json({ error: "Forbidden" }, { status: 403 });
+  }
+
+  const { requestId } = await params;
+  const reqRef = approvalRequestsCol.ref.doc(requestId);
+  const reqDoc = await reqRef.get();
+
+  if (!reqDoc.exists) {
+    return Response.json({ error: "Approval request not found" }, { status: 404 });
+  }
+
+  const approvalData = reqDoc.data()!;
+
+  if (approvalData.status !== "pending") {
+    return Response.json({ error: "Request has already been reviewed" }, { status: 409 });
+  }
+
+  // The requester cannot reject their own request either (keeps it honest)
+  if (approvalData.requested_by === auth.userId) {
+    return Response.json(
+      { error: "You cannot reject your own request. A second admin must review this action." },
+      { status: 403 }
+    );
+  }
+
+  const parsed = await parseJsonBody(request, rejectApprovalSchema);
+  if (!parsed.success) return parsed.response;
+
+  try {
+    const now = new Date().toISOString();
+    await reqRef.update({
+      status: "rejected",
+      reviewer_id: auth.userId,
+      reviewer_note: parsed.data.note || null,
+      reviewed_at: now,
+      updated_at: now,
+    });
+
+    return Response.json({ message: "Approval request rejected" });
+  } catch (err) {
+    console.error("Reject approval request error:", err);
+    return Response.json({ error: "Internal server error" }, { status: 500 });
+  }
+}

--- a/web/src/app/api/approval-requests/route.ts
+++ b/web/src/app/api/approval-requests/route.ts
@@ -1,0 +1,54 @@
+import { approvalRequestsCol, projectsCol, usersCol } from "@/lib/db";
+import { getAuthUser } from "@/lib/auth";
+export const dynamic = "force-dynamic";
+
+export async function GET(request: Request) {
+  const auth = getAuthUser(request);
+  if (!auth || auth.role !== "admin") {
+    return Response.json({ error: "Forbidden" }, { status: 403 });
+  }
+
+  try {
+    const url = new URL(request.url);
+    const status = url.searchParams.get("status") || "pending";
+
+    const snap = await approvalRequestsCol.ref.where("status", "==", status).get();
+
+    const userCache = new Map<number, string>();
+    async function getUsername(uid: number): Promise<string> {
+      if (userCache.has(uid)) return userCache.get(uid)!;
+      const uDoc = await usersCol.ref.doc(String(uid)).get();
+      const name = uDoc.exists ? (uDoc.data()!.username as string) : "unknown";
+      userCache.set(uid, name);
+      return name;
+    }
+
+    const requests = await Promise.all(
+      snap.docs.map(async (d) => {
+        const data = d.data();
+        const projectDoc = await projectsCol.ref.doc(String(data.project_id)).get();
+        const project = projectDoc.exists ? projectDoc.data() : null;
+
+        return {
+          ...data,
+          id: data.numericId,
+          project_name: project?.name ?? "Unknown Project",
+          project_slug: project?.slug ?? "",
+          project_status: project?.status ?? "",
+          requester_username: await getUsername(data.requested_by as number),
+          reviewer_username: data.reviewer_id
+            ? await getUsername(data.reviewer_id as number)
+            : null,
+        };
+      })
+    );
+
+    // Sort by newest first
+    requests.sort((a, b) => (b.created_at > a.created_at ? 1 : -1));
+
+    return Response.json({ approvalRequests: requests });
+  } catch (err) {
+    console.error("List approval requests error:", err);
+    return Response.json({ error: "Internal server error" }, { status: 500 });
+  }
+}

--- a/web/src/app/api/projects/[id]/approve/route.ts
+++ b/web/src/app/api/projects/[id]/approve/route.ts
@@ -27,11 +27,35 @@ export async function PUT(
   const parsed = await parseJsonBody(request, featuredProjectSchema);
   if (!parsed.success) return parsed.response;
 
-  try {
-    const featured = parsed.data.featured ? 1 : 0;
-    const status = featured ? "featured" : "approved";
+  // Featuring a project is a sensitive action — must go through two-person approval.
+  // Callers should POST /api/projects/:id/request-approval instead.
+  if (parsed.data.featured === true) {
+    return Response.json(
+      {
+        error: "Featuring a project requires two-person approval. Use POST /api/projects/:id/request-approval with action 'feature'.",
+        requiresApproval: true,
+        action: "feature",
+      },
+      { status: 403 }
+    );
+  }
 
-    await ref.update({ status, featured, updated_at: new Date().toISOString() });
+  try {
+    // Unfeature (featured → approved) also requires approval workflow
+    const current = doc.data()!;
+    if (current.featured === 1 && parsed.data.featured === false) {
+      return Response.json(
+        {
+          error: "Unfeaturing a project requires two-person approval. Use POST /api/projects/:id/request-approval with action 'unfeature'.",
+          requiresApproval: true,
+          action: "unfeature",
+        },
+        { status: 403 }
+      );
+    }
+
+    // Plain approve (submitted/rejected/delisted → approved, featured stays 0)
+    await ref.update({ status: "approved", featured: 0, updated_at: new Date().toISOString() });
     const updated = await ref.get();
     return Response.json({ project: { ...updated.data(), id: updated.data()!.numericId } });
   } catch (err) {

--- a/web/src/app/api/projects/[id]/delete/route.ts
+++ b/web/src/app/api/projects/[id]/delete/route.ts
@@ -1,4 +1,4 @@
-import { projectsCol, ratingsCol } from "@/lib/db";
+import { projectsCol } from "@/lib/db";
 import { getAuthUser, hasMinRole } from "@/lib/auth";
 export const dynamic = "force-dynamic";
 
@@ -16,12 +16,14 @@ export async function DELETE(
   const doc = await ref.get();
   if (!doc.exists) return Response.json({ error: "Project not found" }, { status: 404 });
 
-  // Delete associated ratings
-  const rSnap = await ratingsCol.ref.where("project_id", "==", Number(id)).get();
-  const batch = projectsCol.ref.firestore.batch();
-  rSnap.docs.forEach((d) => batch.delete(d.ref));
-  batch.delete(ref);
-  await batch.commit();
-
-  return Response.json({ message: "Project deleted" });
+  // Deletion is a sensitive, irreversible action — requires two-person approval.
+  // Callers should POST /api/projects/:id/request-approval with action 'delete'.
+  return Response.json(
+    {
+      error: "Deleting a project requires two-person approval. Use POST /api/projects/:id/request-approval with action 'delete'.",
+      requiresApproval: true,
+      action: "delete",
+    },
+    { status: 403 }
+  );
 }

--- a/web/src/app/api/projects/[id]/request-approval/route.ts
+++ b/web/src/app/api/projects/[id]/request-approval/route.ts
@@ -1,0 +1,63 @@
+import { projectsCol, approvalRequestsCol, nextId } from "@/lib/db";
+import { getAuthUser } from "@/lib/auth";
+import { parseJsonBody } from "@/lib/validation/parse-body";
+import { requestApprovalSchema } from "@/lib/validation/schemas/approval";
+export const dynamic = "force-dynamic";
+
+export async function POST(
+  request: Request,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const auth = getAuthUser(request);
+  if (!auth || auth.role !== "admin") {
+    return Response.json({ error: "Forbidden" }, { status: 403 });
+  }
+
+  const { id } = await params;
+  const ref = projectsCol.ref.doc(id);
+  const doc = await ref.get();
+  if (!doc.exists) return Response.json({ error: "Project not found" }, { status: 404 });
+
+  const parsed = await parseJsonBody(request, requestApprovalSchema);
+  if (!parsed.success) return parsed.response;
+
+  const { action, reason } = parsed.data;
+
+  // Check if there's already a pending request for this project+action
+  const existing = await approvalRequestsCol.ref
+    .where("project_id", "==", Number(id))
+    .where("action_type", "==", action)
+    .where("status", "==", "pending")
+    .get();
+
+  if (!existing.empty) {
+    return Response.json(
+      { error: "A pending approval request already exists for this action" },
+      { status: 409 }
+    );
+  }
+
+  try {
+    const numericId = await nextId("approval_requests");
+    const now = new Date().toISOString();
+    const data = {
+      numericId,
+      project_id: Number(id),
+      action_type: action,
+      requested_by: auth.userId,
+      status: "pending",
+      reason: reason || null,
+      reviewer_id: null,
+      reviewer_note: null,
+      reviewed_at: null,
+      created_at: now,
+      updated_at: now,
+    };
+
+    await approvalRequestsCol.ref.doc(String(numericId)).set(data);
+    return Response.json({ approvalRequest: data }, { status: 201 });
+  } catch (err) {
+    console.error("Request approval error:", err);
+    return Response.json({ error: "Internal server error" }, { status: 500 });
+  }
+}

--- a/web/src/components/ApprovalQueue.tsx
+++ b/web/src/components/ApprovalQueue.tsx
@@ -1,0 +1,257 @@
+"use client";
+
+import { useState } from "react";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import Link from "next/link";
+import { Textarea } from "@/components/ui/textarea";
+import {
+  AlertDialog,
+  AlertDialogTrigger,
+  AlertDialogContent,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogCancel,
+  AlertDialogAction,
+} from "@/components/ui/alert-dialog";
+import type { ApprovalRequest } from "@/types/approval";
+
+const ACTION_LABELS: Record<string, { label: string; color: string }> = {
+  feature: { label: "Mark Featured", color: "text-solar-bright" },
+  unfeature: { label: "Remove from Featured", color: "text-ash" },
+  delete: { label: "Delete Project", color: "text-supernova" },
+};
+
+function ReviewDialog({
+  item,
+  currentUserId: currentUserId,
+  onApprove,
+  onReject,
+  isPending,
+}: {
+  item: ApprovalRequest;
+  currentUserId: number;
+  onApprove: (requestId: number, note: string) => void;
+  onReject: (requestId: number, note: string) => void;
+  isPending: boolean;
+}) {
+  const [note, setNote] = useState("");
+  const [open, setOpen] = useState(false);
+  const isSelf = item.requested_by === currentUserId;
+  const meta = ACTION_LABELS[item.action_type] ?? { label: item.action_type, color: "text-moonlight" };
+
+  return (
+    <AlertDialog open={open} onOpenChange={setOpen}>
+      <AlertDialogTrigger asChild>
+        <button
+          disabled={isPending}
+          className="bg-aurora/15 hover:bg-aurora/25 text-aurora-bright border border-aurora/20 font-medium text-xs px-3 py-1.5 rounded-lg transition-all disabled:opacity-50"
+        >
+          Review
+        </button>
+      </AlertDialogTrigger>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>Review approval request</AlertDialogTitle>
+          <AlertDialogDescription asChild>
+            <div className="space-y-2 text-sm">
+              <p>
+                <span className="text-moonlight font-medium">{item.requester_username}</span> requested to{" "}
+                <span className={`font-semibold ${meta.color}`}>{meta.label}</span>{" "}
+                <span className="text-moonlight font-medium">&ldquo;{item.project_name}&rdquo;</span>.
+              </p>
+              {item.reason && (
+                <p className="text-ash italic">&ldquo;{item.reason}&rdquo;</p>
+              )}
+              {isSelf && (
+                <p className="text-supernova font-medium">
+                  ⚠ You submitted this request and cannot review it yourself.
+                </p>
+              )}
+            </div>
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <div className="space-y-2">
+          <label className="text-sm font-medium text-moonlight">
+            Note <span className="text-ash">(optional)</span>
+          </label>
+          <Textarea
+            placeholder="Add a note for the audit log..."
+            value={note}
+            onChange={(e) => setNote(e.target.value)}
+            rows={2}
+            disabled={isSelf}
+          />
+        </div>
+        <AlertDialogFooter>
+          <AlertDialogCancel onClick={() => setNote("")}>Cancel</AlertDialogCancel>
+          <button
+            disabled={isSelf || isPending}
+            onClick={() => {
+              onReject(item.id, note);
+              setNote("");
+              setOpen(false);
+            }}
+            className="bg-supernova/15 hover:bg-supernova/25 text-supernova border border-supernova/20 font-medium text-sm px-4 py-2 rounded-xl transition-all disabled:opacity-50"
+          >
+            Reject
+          </button>
+          <AlertDialogAction
+            disabled={isSelf || isPending}
+            onClick={() => {
+              onApprove(item.id, note);
+              setNote("");
+              setOpen(false);
+            }}
+            className="disabled:opacity-50"
+          >
+            Approve &amp; Execute
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+}
+
+export function ApprovalQueue({
+  token,
+  currentUserId,
+}: {
+  token: string | null;
+  currentUserId: number;
+}) {
+  const qc = useQueryClient();
+
+  const { data: items = [], isLoading } = useQuery<ApprovalRequest[]>({
+    queryKey: ["approval-requests", "pending"],
+    queryFn: async () => {
+      const res = await fetch("/api/approval-requests?status=pending", {
+        headers: { Authorization: `Bearer ${token}` },
+      });
+      if (!res.ok) throw new Error("Failed to fetch approval requests");
+      const data = await res.json();
+      return data.approvalRequests || [];
+    },
+    enabled: !!token,
+  });
+
+  const reviewMutation = useMutation({
+    mutationFn: async ({
+      requestId,
+      decision,
+      note,
+    }: {
+      requestId: number;
+      decision: "approve" | "reject";
+      note: string;
+    }) => {
+      const res = await fetch(`/api/approval-requests/${requestId}/${decision}`, {
+        method: "PUT",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${token}`,
+        },
+        body: JSON.stringify({ note: note || undefined }),
+      });
+      if (!res.ok) {
+        const data = await res.json();
+        throw new Error(data.error || "Review failed");
+      }
+    },
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ["approval-requests"] });
+      qc.invalidateQueries({ queryKey: ["admin-projects"] });
+    },
+  });
+
+  if (isLoading) {
+    return (
+      <div className="space-y-3">
+        {[...Array(2)].map((_, i) => (
+          <div key={i} className="skeleton h-20 rounded-xl" />
+        ))}
+      </div>
+    );
+  }
+
+  if (items.length === 0) {
+    return (
+      <div className="glass rounded-2xl p-12 text-center">
+        <div className="w-16 h-16 mx-auto mb-4 rounded-2xl bg-stardust/50 flex items-center justify-center">
+          <svg width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="var(--aurora)" strokeWidth="1.5">
+            <polyline points="20 6 9 17 4 12" />
+          </svg>
+        </div>
+        <h3 className="font-semibold text-lg text-moonlight mb-2">No pending approvals</h3>
+        <p className="text-ash">Sensitive actions awaiting a second admin will appear here</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      {reviewMutation.isError && (
+        <div className="bg-supernova/10 border border-supernova/20 text-supernova rounded-xl px-4 py-3 text-sm">
+          {reviewMutation.error.message}
+        </div>
+      )}
+      {items.map((item) => {
+        const meta = ACTION_LABELS[item.action_type] ?? { label: item.action_type, color: "text-moonlight" };
+        return (
+          <div
+            key={item.id}
+            className="glass rounded-xl p-4 flex flex-col sm:flex-row sm:items-center gap-3 transition-all hover:border-dust/40"
+          >
+            <div className="flex-1 min-w-0">
+              <div className="flex items-center gap-2 mb-1 flex-wrap">
+                <Link
+                  href={`/projects/${item.project_slug}`}
+                  className="font-medium text-starlight hover:text-nova-bright transition-colors truncate"
+                  target="_blank"
+                >
+                  {item.project_name}
+                </Link>
+                <span className={`text-xs font-semibold px-2 py-0.5 rounded-md bg-stardust/50 border border-dust/20 ${meta.color}`}>
+                  {meta.label}
+                </span>
+                <span className="tag text-xs bg-solar/10 text-solar-bright border border-solar/20">
+                  pending
+                </span>
+              </div>
+              <div className="flex flex-wrap gap-x-4 gap-y-0.5 text-xs text-ash">
+                <span>
+                  requested by{" "}
+                  <span className="text-moonlight">{item.requester_username}</span>
+                  {item.requested_by === currentUserId && (
+                    <span className="ml-1 text-solar-bright">(you)</span>
+                  )}
+                </span>
+                <span>{new Date(item.created_at).toLocaleDateString()}</span>
+              </div>
+              {item.reason && (
+                <p className="text-xs text-ash/70 italic mt-1 truncate max-w-[300px]">
+                  &ldquo;{item.reason}&rdquo;
+                </p>
+              )}
+            </div>
+
+            <div className="shrink-0">
+              <ReviewDialog
+                item={item}
+                currentUserId={currentUserId}
+                isPending={reviewMutation.isPending}
+                onApprove={(id, note) =>
+                  reviewMutation.mutate({ requestId: id, decision: "approve", note })
+                }
+                onReject={(id, note) =>
+                  reviewMutation.mutate({ requestId: id, decision: "reject", note })
+                }
+              />
+            </div>
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/web/src/lib/db.ts
+++ b/web/src/lib/db.ts
@@ -31,6 +31,11 @@ export const submissionNotesCol = {
 		return col("submission_notes");
 	},
 };
+export const approvalRequestsCol = {
+	get ref() {
+		return col("approval_requests");
+	},
+};
 
 // Auto-incrementing numeric ID
 export async function nextId(collection: string): Promise<number> {

--- a/web/src/lib/validation/schemas/approval.ts
+++ b/web/src/lib/validation/schemas/approval.ts
@@ -1,0 +1,17 @@
+import { z } from "zod";
+
+export const requestApprovalSchema = z.object({
+  action: z.enum(["feature", "unfeature", "delete"]),
+  reason: z.string().optional(),
+});
+
+export const reviewApprovalSchema = z.object({
+  note: z.string().optional(),
+});
+
+export const rejectApprovalSchema = z.object({
+  note: z.string().optional(),
+});
+
+export type RequestApprovalInput = z.infer<typeof requestApprovalSchema>;
+export type ReviewApprovalInput = z.infer<typeof reviewApprovalSchema>;

--- a/web/src/types/approval.ts
+++ b/web/src/types/approval.ts
@@ -1,0 +1,21 @@
+export type ApprovalAction = "feature" | "unfeature" | "delete";
+export type ApprovalStatus = "pending" | "approved" | "rejected";
+
+export interface ApprovalRequest {
+  id: number;
+  project_id: number;
+  action_type: ApprovalAction;
+  requested_by: number;
+  status: ApprovalStatus;
+  reason?: string;
+  reviewer_id?: number;
+  reviewer_note?: string;
+  reviewed_at?: string;
+  created_at: string;
+  updated_at: string;
+  // Enriched fields from API
+  project_name?: string;
+  project_slug?: string;
+  requester_username?: string;
+  reviewer_username?: string;
+}


### PR DESCRIPTION
closes #248

Sensitive actions (feature, unfeature, delete) now require a second admin to confirm before executing. The admin who initiated the request cannot approve it themselves - enforced at the API level.

Changes:
- Add approval_requests Firestore collection + SQL migration
- POST /api/projects/:id/request-approval - submit a pending request
- GET  /api/approval-requests - list requests by status
- PUT  /api/approval-requests/:id/approve - second admin approves + executes
- PUT  /api/approval-requests/:id/reject  - second admin rejects
- /api/projects/:id/approve blocks feature/unfeature with 403 requiresApproval
- /api/projects/:id/delete  blocks deletion with 403 requiresApproval
- Admin UI: Feature/Unfeature/Delete buttons replaced with RequestApprovalDialog
- Admin UI: new Approvals tab with ApprovalQueue component