### PR TITLE
feat: add internal submission notes for admins

### DIFF
--- a/web/data/supabase/006_add_submission_notes.sql
+++ b/web/data/supabase/006_add_submission_notes.sql
@@ -1,0 +1,36 @@
+-- Migration 006: Add submission_notes table
+-- Internal review notes on project submissions, visible to admins only.
+
+begin;
+
+create table if not exists public.submission_notes (
+  id         bigserial primary key,
+  project_id bigint      not null,
+  author_id  bigint      not null,
+  body       text        not null,
+  created_at timestamptz not null default now(),
+
+  constraint submission_notes_project_id_fkey
+    foreign key (project_id)
+    references public.projects ("numericId")
+    on delete cascade,
+
+  constraint submission_notes_author_id_fkey
+    foreign key (author_id)
+    references public.users ("numericId")
+    on delete cascade
+);
+
+create index if not exists submission_notes_project_id_idx
+  on public.submission_notes (project_id);
+
+create index if not exists submission_notes_created_at_idx
+  on public.submission_notes (created_at asc);
+
+-- RLS: table is backend-only.
+-- All access goes through the Next.js API using the service-role key,
+-- so no anon/authenticated client policies are needed.
+-- Enabling RLS blocks any direct client access.
+alter table public.submission_notes enable row level security;
+
+commit;

--- a/web/src/app/api/notes/[projectId]/route.ts
+++ b/web/src/app/api/notes/[projectId]/route.ts
@@ -1,0 +1,107 @@
+import { getSupabase } from "@/lib/firebase";
+import { projectsCol } from "@/lib/db";
+import { getAuthUser } from "@/lib/auth";
+import { parseJsonBody } from "@/lib/validation/parse-body";
+import { createNoteSchema } from "@/lib/validation/schemas/notes";
+
+export const dynamic = "force-dynamic";
+
+// GET /api/notes/[projectId] — list all notes for a project (admin only)
+export async function GET(
+  request: Request,
+  { params }: { params: Promise<{ projectId: string }> },
+) {
+  const auth = getAuthUser(request);
+  if (!auth || auth.role !== "admin") {
+    return Response.json({ error: "Forbidden" }, { status: 403 });
+  }
+
+  const { projectId } = await params;
+  const numericProjectId = Number(projectId);
+  if (Number.isNaN(numericProjectId)) {
+    return Response.json({ error: "Invalid project ID" }, { status: 400 });
+  }
+
+  // Verify project exists
+  const pDoc = await projectsCol.ref.doc(projectId).get();
+  if (!pDoc.exists) {
+    return Response.json({ error: "Project not found" }, { status: 404 });
+  }
+
+  try {
+    const supabase = getSupabase();
+    const { data, error } = await supabase
+      .from("submission_notes")
+      .select(
+        "id, project_id, author_id, body, created_at, users:author_id(username)",
+      )
+      .eq("project_id", numericProjectId)
+      .order("created_at", { ascending: true });
+
+    if (error) throw error;
+
+    const notes = (data ?? []).map((row: Record<string, unknown>) => ({
+      id: row.id,
+      project_id: row.project_id,
+      author_id: row.author_id,
+      body: row.body,
+      created_at: row.created_at,
+      author_username:
+        row.users && typeof row.users === "object" && !Array.isArray(row.users)
+          ? (row.users as Record<string, unknown>).username
+          : null,
+    }));
+
+    return Response.json({ notes });
+  } catch (err) {
+    console.error("Notes GET error:", err);
+    return Response.json({ error: "Internal server error" }, { status: 500 });
+  }
+}
+
+// POST /api/notes/[projectId] — add a note to a project (admin only)
+export async function POST(
+  request: Request,
+  { params }: { params: Promise<{ projectId: string }> },
+) {
+  const auth = getAuthUser(request);
+  if (!auth || auth.role !== "admin") {
+    return Response.json({ error: "Forbidden" }, { status: 403 });
+  }
+
+  const { projectId } = await params;
+  const numericProjectId = Number(projectId);
+  if (Number.isNaN(numericProjectId)) {
+    return Response.json({ error: "Invalid project ID" }, { status: 400 });
+  }
+
+  // Verify project exists
+  const pDoc = await projectsCol.ref.doc(projectId).get();
+  if (!pDoc.exists) {
+    return Response.json({ error: "Project not found" }, { status: 404 });
+  }
+
+  const parsed = await parseJsonBody(request, createNoteSchema);
+  if (!parsed.success) return parsed.response;
+
+  try {
+    const supabase = getSupabase();
+    const { data, error } = await supabase
+      .from("submission_notes")
+      .insert({
+        project_id: numericProjectId,
+        author_id: auth.userId,
+        body: parsed.data.body,
+        created_at: new Date().toISOString(),
+      })
+      .select("id, project_id, author_id, body, created_at")
+      .single();
+
+    if (error) throw error;
+
+    return Response.json({ note: data }, { status: 201 });
+  } catch (err) {
+    console.error("Notes POST error:", err);
+    return Response.json({ error: "Internal server error" }, { status: 500 });
+  }
+}

--- a/web/src/app/queue/page.tsx
+++ b/web/src/app/queue/page.tsx
@@ -2,6 +2,7 @@
 
 import { useQuery } from "@tanstack/react-query";
 import Link from "next/link";
+import SubmissionNotes from "@/components/SubmissionNotes";
 
 interface QueueProject {
   id: number;
@@ -149,6 +150,7 @@ export default function QueuePage() {
                   </div>
                 </div>
               </div>
+              <SubmissionNotes projectId={project.id} />
             </div>
           ))}
         </div>

--- a/web/src/components/SubmissionNotes.tsx
+++ b/web/src/components/SubmissionNotes.tsx
@@ -1,0 +1,222 @@
+"use client";
+
+import { useState, useRef, useEffect } from "react";
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { useAuth } from "@/context/AuthContext";
+
+interface Note {
+  id: number;
+  project_id: number;
+  author_id: number;
+  body: string;
+  created_at: string;
+  author_username?: string | null;
+}
+
+interface SubmissionNotesProps {
+  projectId: number;
+}
+
+function timeAgo(dateStr: string) {
+  const diff = Date.now() - new Date(dateStr).getTime();
+  const mins = Math.floor(diff / 60000);
+  if (mins < 1) return "just now";
+  if (mins < 60) return `${mins}m ago`;
+  const hrs = Math.floor(mins / 60);
+  if (hrs < 24) return `${hrs}h ago`;
+  const days = Math.floor(hrs / 24);
+  return `${days}d ago`;
+}
+
+export default function SubmissionNotes({ projectId }: SubmissionNotesProps) {
+  const { token, user } = useAuth();
+  const queryClient = useQueryClient();
+  const [open, setOpen] = useState(false);
+  const [draft, setDraft] = useState("");
+  const [submitError, setSubmitError] = useState<string | null>(null);
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+
+  // Only admins can access notes
+  if (!user || user.role !== "admin") return null;
+
+  const queryKey = ["submission-notes", projectId];
+
+  const { data, isLoading } = useQuery<{ notes: Note[] }>({
+    queryKey,
+    queryFn: () =>
+      fetch(`/api/notes/${projectId}`, {
+        headers: { Authorization: `Bearer ${token}` },
+      }).then((r) => {
+        if (!r.ok) throw new Error("Failed to fetch notes");
+        return r.json();
+      }),
+    enabled: open, // only fetch when panel is expanded
+    staleTime: 30_000,
+  });
+
+  const notes = data?.notes ?? [];
+
+  const { mutate: addNote, isPending } = useMutation({
+    mutationFn: async (body: string) => {
+      const res = await fetch(`/api/notes/${projectId}`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${token}`,
+        },
+        body: JSON.stringify({ body }),
+      });
+      if (!res.ok) {
+        const err = await res.json();
+        throw new Error(err.error || "Failed to add note");
+      }
+      return res.json();
+    },
+    onSuccess: () => {
+      setDraft("");
+      setSubmitError(null);
+      queryClient.invalidateQueries({ queryKey });
+    },
+    onError: (err: Error) => {
+      setSubmitError(err.message);
+    },
+  });
+
+  // Auto-resize textarea
+  useEffect(() => {
+    if (textareaRef.current) {
+      textareaRef.current.style.height = "auto";
+      textareaRef.current.style.height = `${textareaRef.current.scrollHeight}px`;
+    }
+  }, [draft]);
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    const trimmed = draft.trim();
+    if (!trimmed) return;
+    addNote(trimmed);
+  };
+
+  return (
+    <div className="mt-4 border-t border-dust/20 pt-3">
+      {/* Toggle button */}
+      <button
+        type="button"
+        onClick={() => setOpen((v) => !v)}
+        className="flex items-center gap-2 text-xs text-ash hover:text-moonlight transition-colors group"
+      >
+        {/* Lock icon — internal only signal */}
+        <svg
+          width="13"
+          height="13"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2"
+          className="opacity-60 group-hover:opacity-100 transition-opacity"
+        >
+          <rect x="3" y="11" width="18" height="11" rx="2" ry="2" />
+          <path d="M7 11V7a5 5 0 0 1 10 0v4" />
+        </svg>
+        <span className="font-medium">
+          Internal notes
+          {notes.length > 0 && (
+            <span className="ml-1.5 inline-flex items-center justify-center w-4 h-4 rounded-full bg-nova/20 text-nova-bright text-[10px] font-bold">
+              {notes.length}
+            </span>
+          )}
+        </span>
+        <svg
+          width="12"
+          height="12"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2"
+          className={`transition-transform duration-200 ${open ? "rotate-180" : ""}`}
+        >
+          <polyline points="6 9 12 15 18 9" />
+        </svg>
+      </button>
+
+      {/* Expanded panel */}
+      {open && (
+        <div className="mt-3 space-y-3">
+          {/* Admin-only badge */}
+          <div className="flex items-center gap-1.5">
+            <span className="inline-flex items-center gap-1 text-[10px] font-semibold uppercase tracking-wider text-nova-bright bg-nova/10 border border-nova/20 rounded px-1.5 py-0.5">
+              <svg width="9" height="9" viewBox="0 0 24 24" fill="currentColor">
+                <path d="M12 1L3 5v6c0 5.55 3.84 10.74 9 12 5.16-1.26 9-6.45 9-12V5l-9-4z" />
+              </svg>
+              Admin only · not visible to submitters
+            </span>
+          </div>
+
+          {/* Notes list */}
+          {isLoading ? (
+            <div className="space-y-2">
+              {[...Array(2)].map((_, i) => (
+                <div key={i} className="skeleton h-10 rounded-xl" />
+              ))}
+            </div>
+          ) : notes.length === 0 ? (
+            <p className="text-xs text-ash italic">No notes yet. Be the first to add one.</p>
+          ) : (
+            <ul className="space-y-2">
+              {notes.map((note) => (
+                <li
+                  key={note.id}
+                  className="rounded-xl bg-stardust/30 border border-dust/20 px-3 py-2.5"
+                >
+                  <div className="flex items-baseline justify-between gap-2 mb-1">
+                    <span className="text-xs font-semibold text-moonlight">
+                      {note.author_username ?? `User #${note.author_id}`}
+                    </span>
+                    <span className="text-[10px] text-ash shrink-0">
+                      {timeAgo(note.created_at)}
+                    </span>
+                  </div>
+                  <p className="text-sm text-moonlight/90 whitespace-pre-wrap break-words leading-relaxed">
+                    {note.body}
+                  </p>
+                </li>
+              ))}
+            </ul>
+          )}
+
+          {/* Add note form */}
+          <form onSubmit={handleSubmit} className="space-y-2">
+            <textarea
+              ref={textareaRef}
+              value={draft}
+              onChange={(e) => setDraft(e.target.value)}
+              placeholder="Add an internal note…"
+              rows={2}
+              maxLength={4000}
+              className="w-full resize-none rounded-xl bg-stardust/50 border border-dust/30 focus:border-nova/40 focus:outline-none px-3 py-2 text-sm text-moonlight placeholder:text-ash/50 transition-colors leading-relaxed"
+              onKeyDown={(e) => {
+                if (e.key === "Enter" && (e.metaKey || e.ctrlKey)) {
+                  e.preventDefault();
+                  handleSubmit(e as unknown as React.FormEvent);
+                }
+              }}
+            />
+            {submitError && (
+              <p className="text-xs text-supernova">{submitError}</p>
+            )}
+            <div className="flex items-center justify-between">
+              <span className="text-[10px] text-ash">⌘↵ to submit</span>
+              <button
+                type="submit"
+                disabled={!draft.trim() || isPending}
+                className="btn-nova text-xs px-3 py-1.5 disabled:opacity-40 disabled:cursor-not-allowed"
+              >
+                {isPending ? "Saving…" : "Add note"}
+              </button>
+            </div>
+          </form>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/web/src/lib/db.ts
+++ b/web/src/lib/db.ts
@@ -26,6 +26,11 @@ export const financialSnapshotsCol = {
 		return col("financial_snapshots");
 	},
 };
+export const submissionNotesCol = {
+	get ref() {
+		return col("submission_notes");
+	},
+};
 
 // Auto-incrementing numeric ID
 export async function nextId(collection: string): Promise<number> {

--- a/web/src/lib/firebase.ts
+++ b/web/src/lib/firebase.ts
@@ -10,6 +10,7 @@ const TABLE_BY_COLLECTION: Record<string, string> = {
 	financial_snapshots: "financial_snapshots",
 	auth_challenges: "auth_challenges",
 	counters: "counters",
+	submission_notes: "submission_notes",
 };
 
 function resolveTable(collection: string): string {

--- a/web/src/lib/validation/schemas/notes.ts
+++ b/web/src/lib/validation/schemas/notes.ts
@@ -1,0 +1,7 @@
+import { z } from "zod";
+
+export const createNoteSchema = z.object({
+  body: z.string().min(1, "Note body is required").max(4000, "Note body must be 4000 characters or fewer"),
+});
+
+export type CreateNoteInput = z.infer<typeof createNoteSchema>;


### PR DESCRIPTION

  
  Add internal submission notes for admins
  
  Adds a private notes system that lets admins leave internal review comments on project
  submissions. Notes are never exposed to submitters or the public.
  
  Changes
  
  - DB — new submission_notes table (id, project_id, author_id, body, created_at) with FK
  constraints to projects and users, cascading deletes, and RLS enabled (no client-facing
  policies — service-role key only). Migration: 006_add_submission_notes.sql.
  - API — GET /api/notes/[projectId] and POST /api/notes/[projectId], both returning 403 for any
  non-admin caller. GET returns notes in chronological order with author_username joined from
  users. POST validates the body with Zod (1–4000 chars).
  - UI — new SubmissionNotes component added to each card on the Approval Queue page. The panel
  is collapsed by default (lazy-fetches on open), shows a note count badge, displays an "Admin
  only · not visible to submitters" label, and includes an add-note form with auto-resize
  textarea and Cmd/Ctrl+Enter shortcut. Non-admin users get null rendered — the component is a
  no-op for them.
  
  Testing
  
  - Log in as admin → open /queue → expand "Internal notes" on any pending project → add a note →
  verify it appears
  - Log in as a contributor → confirm the notes panel is not rendered
  - Hit GET /api/notes/:id or POST /api/notes/:id without an admin token → expect 403 Forbidden
  - Run migration 006_add_submission_notes.sql in Supabase SQL Editor before testing

▸ Closes #242 