### PR TITLE
feat: add maintainer activity stats and leaderboard

### DIFF
--- a/web/data/supabase/005_add_moderation_log.sql
+++ b/web/data/supabase/005_add_moderation_log.sql
@@ -1,0 +1,27 @@
+-- Moderation Log Table for tracking admin/maintainer actions
+-- This table tracks all moderation actions (approvals, rejections, reviews)
+-- for generating maintainer stats and leaderboards
+
+create table if not exists public.moderation_log (
+  id bigserial primary key,
+  admin_id bigint not null,
+  admin_username text not null,
+  project_id bigint not null,
+  project_name text not null,
+  action text not null, -- 'approve', 'reject', 'feature', 'delist', 'review'
+  action_details jsonb default '{}'::jsonb,
+  created_at timestamptz not null default now(),
+  constraint moderation_log_admin_id_fkey
+    foreign key (admin_id)
+    references public.users ("numericId")
+    on delete restrict,
+  constraint moderation_log_project_id_fkey
+    foreign key (project_id)
+    references public.projects ("numericId")
+    on delete cascade
+);
+
+create index if not exists moderation_log_admin_id_idx on public.moderation_log (admin_id);
+create index if not exists moderation_log_action_idx on public.moderation_log (action);
+create index if not exists moderation_log_created_at_idx on public.moderation_log (created_at desc);
+create index if not exists moderation_log_project_id_idx on public.moderation_log (project_id);

--- a/web/src/app/admin/page.tsx
+++ b/web/src/app/admin/page.tsx
@@ -90,6 +90,30 @@ function usePendingProjects(token: string | null) {
   });
 }
 
+function useMaintainerLeaderboard(token: string | null) {
+  return useQuery<{
+    admin_id: number;
+    admin_username: string;
+    total_reviews: number;
+    approvals: number;
+    rejections: number;
+    features: number;
+    delists: number;
+    rank: number;
+  }[]>({
+    queryKey: ["maintainer-leaderboard"],
+    queryFn: async () => {
+      const res = await fetch("/api/admin/maintainer-stats", {
+        headers: { Authorization: `Bearer ${token}` },
+      });
+      if (!res.ok) throw new Error("Failed to fetch leaderboard");
+      const data = await res.json();
+      return data.leaderboard || [];
+    },
+    enabled: !!token,
+  });
+}
+
 // ─── Action hooks ───────────────────────────────────────────────────
 
 function useProjectAction(token: string | null) {
@@ -931,6 +955,7 @@ export default function AdminPage() {
   const { data: approved = [], isLoading: approvedLoading } = useAdminProjects("approved", token);
   const { data: featured = [], isLoading: featuredLoading } = useAdminProjects("featured", token);
   const { data: all = [], isLoading: allLoading } = useAdminProjects(null, token);
+  const { data: leaderboard = [], isLoading: leaderboardLoading } = useMaintainerLeaderboard(token);
 
   const filteredPending = filterProjects(pending, search);
   const filteredApproved = filterProjects(approved, search);
@@ -1059,6 +1084,7 @@ export default function AdminPage() {
               )}
             </TabsTrigger>
             <TabsTrigger value="all">All Projects</TabsTrigger>
+            <TabsTrigger value="leaderboard">Leaderboard</TabsTrigger>
             <TabsTrigger value="contract">
               Contract
               {ON_CHAIN_ENABLED && (
@@ -1188,6 +1214,74 @@ export default function AdminPage() {
                 }
                 title="No projects yet"
                 subtitle="Projects will appear here once submitted"
+              />
+            )}
+          </TabsContent>
+
+          {/* ── Leaderboard tab ── */}
+          <TabsContent value="leaderboard">
+            {leaderboardLoading ? (
+              <Skeletons count={5} />
+            ) : leaderboard.length > 0 ? (
+              <div className="glass rounded-2xl overflow-hidden">
+                <table className="w-full">
+                  <thead>
+                    <tr className="border-b border-dust/20">
+                      <th className="text-left text-xs font-medium text-ash uppercase tracking-wider px-6 py-4">Rank</th>
+                      <th className="text-left text-xs font-medium text-ash uppercase tracking-wider px-6 py-4">Maintainer</th>
+                      <th className="text-center text-xs font-medium text-ash uppercase tracking-wider px-6 py-4">Total</th>
+                      <th className="text-center text-xs font-medium text-ash uppercase tracking-wider px-6 py-4">Approvals</th>
+                      <th className="text-center text-xs font-medium text-ash uppercase tracking-wider px-6 py-4">Rejections</th>
+                      <th className="text-center text-xs font-medium text-ash uppercase tracking-wider px-6 py-4">Featured</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {leaderboard.map((entry) => (
+                      <tr key={entry.admin_id} className="border-b border-dust/10 hover:bg-stardust/20 transition-colors">
+                        <td className="px-6 py-4">
+                          <div className={`w-8 h-8 rounded-full flex items-center justify-center font-bold text-sm ${
+                            entry.rank === 1 ? 'bg-solar/20 text-solar-bright' :
+                            entry.rank === 2 ? 'bg-aurora/20 text-aurora-bright' :
+                            entry.rank === 3 ? 'bg-plasma/20 text-plasma-bright' :
+                            'bg-stardust/30 text-ash'
+                          }`}>
+                            {entry.rank}
+                          </div>
+                        </td>
+                        <td className="px-6 py-4">
+                          <span className="font-medium text-moonlight">{entry.admin_username}</span>
+                        </td>
+                        <td className="px-6 py-4 text-center">
+                          <span className="font-bold text-starlight">{entry.total_reviews}</span>
+                        </td>
+                        <td className="px-6 py-4 text-center">
+                          <span className="text-aurora-bright">{entry.approvals}</span>
+                        </td>
+                        <td className="px-6 py-4 text-center">
+                          <span className="text-supernova">{entry.rejections}</span>
+                        </td>
+                        <td className="px-6 py-4 text-center">
+                          <span className="text-solar-bright">{entry.features}</span>
+                        </td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            ) : (
+              <EmptyState
+                icon={
+                  <svg width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="var(--ash)" strokeWidth="1.5">
+                    <path d="M6 9H4.5a2.5 2.5 0 0 1 0-5H6" />
+                    <path d="M18 9h1.5a2.5 2.5 0 0 0 0-5H18" />
+                    <path d="M4 22h16" />
+                    <path d="M10 14.66V17c0 .55-.47.98-.97 1.21C7.85 18.75 7 20.24 7 22" />
+                    <path d="M14 14.66V17c0 .55.47.98.97 1.21C16.15 18.75 17 20.24 17 22" />
+                    <path d="M18 2H6v7a6 6 0 0 0 12 0V2Z" />
+                  </svg>
+                }
+                title="No activity yet"
+                subtitle="Moderation activity will appear here once maintainers start reviewing projects"
               />
             )}
           </TabsContent>

--- a/web/src/app/api/admin/maintainer-stats/[userId]/route.ts
+++ b/web/src/app/api/admin/maintainer-stats/[userId]/route.ts
@@ -1,0 +1,78 @@
+import { moderationLogCol } from "@/lib/db";
+import { getAuthUser } from "@/lib/auth";
+export const dynamic = "force-dynamic";
+
+export async function GET(
+  request: Request,
+  { params }: { params: Promise<{ userId: string }> }
+) {
+  const auth = getAuthUser(request);
+  if (!auth || auth.role !== "admin") {
+    return Response.json({ error: "Forbidden" }, { status: 403 });
+  }
+
+  const { userId } = await params;
+
+  try {
+    // Fetch moderation logs for specific admin
+    const logSnap = await moderationLogCol.ref
+      .where("admin_id", "==", parseInt(userId))
+      .get();
+
+    // Aggregate stats
+    const stats = {
+      total_reviews: 0,
+      approvals: 0,
+      rejections: 0,
+      features: 0,
+      delists: 0,
+      recent_actions: [] as Array<{
+        action: string;
+        project_name: string;
+        created_at: string;
+      }>,
+    };
+
+    logSnap.docs.forEach((doc) => {
+      const log = doc.data();
+      const action = log.action as string;
+
+      stats.total_reviews++;
+
+      switch (action) {
+        case "approve":
+          stats.approvals++;
+          break;
+        case "reject":
+          stats.rejections++;
+          break;
+        case "feature":
+          stats.features++;
+          break;
+        case "delist":
+          stats.delists++;
+          break;
+      }
+    });
+
+    // Get recent actions (last 10)
+    const recentDocs = logSnap.docs
+      .sort((a, b) => {
+        const aTime = new Date(a.data().created_at as string).getTime();
+        const bTime = new Date(b.data().created_at as string).getTime();
+        return bTime - aTime;
+      })
+      .slice(0, 10);
+
+    stats.recent_actions = recentDocs.map((doc) => ({
+      action: doc.data().action as string,
+      project_name: doc.data().project_name as string,
+      created_at: doc.data().created_at as string,
+    }));
+
+    return Response.json({ stats });
+  } catch (err) {
+    console.error("Individual maintainer stats error:", err);
+    return Response.json({ error: "Internal server error" }, { status: 500 });
+  }
+}

--- a/web/src/app/api/admin/maintainer-stats/route.ts
+++ b/web/src/app/api/admin/maintainer-stats/route.ts
@@ -1,0 +1,78 @@
+import { moderationLogCol, usersCol } from "@/lib/db";
+import { getAuthUser } from "@/lib/auth";
+export const dynamic = "force-dynamic";
+
+export async function GET(request: Request) {
+  const auth = getAuthUser(request);
+  if (!auth || auth.role !== "admin") {
+    return Response.json({ error: "Forbidden" }, { status: 403 });
+  }
+
+  try {
+    // Fetch all moderation logs
+    const logSnap = await moderationLogCol.ref.get();
+    
+    // Aggregate stats by admin
+    const statsByAdmin = new Map<number, {
+      admin_id: number;
+      admin_username: string;
+      total_reviews: number;
+      approvals: number;
+      rejections: number;
+      features: number;
+      delists: number;
+    }>();
+
+    logSnap.docs.forEach((doc) => {
+      const log = doc.data();
+      const adminId = log.admin_id as number;
+      const adminUsername = log.admin_username as string;
+      const action = log.action as string;
+
+      if (!statsByAdmin.has(adminId)) {
+        statsByAdmin.set(adminId, {
+          admin_id: adminId,
+          admin_username: adminUsername,
+          total_reviews: 0,
+          approvals: 0,
+          rejections: 0,
+          features: 0,
+          delists: 0,
+        });
+      }
+
+      const stats = statsByAdmin.get(adminId)!;
+      stats.total_reviews++;
+
+      switch (action) {
+        case "approve":
+          stats.approvals++;
+          break;
+        case "reject":
+          stats.rejections++;
+          break;
+        case "feature":
+          stats.features++;
+          break;
+        case "delist":
+          stats.delists++;
+          break;
+      }
+    });
+
+    // Convert to array and sort by total_reviews descending
+    const leaderboard = Array.from(statsByAdmin.values()).sort(
+      (a, b) => b.total_reviews - a.total_reviews
+    );
+
+    // Add rank
+    leaderboard.forEach((stats, index) => {
+      (stats as any).rank = index + 1;
+    });
+
+    return Response.json({ leaderboard });
+  } catch (err) {
+    console.error("Maintainer stats error:", err);
+    return Response.json({ error: "Internal server error" }, { status: 500 });
+  }
+}

--- a/web/src/app/api/projects/[id]/approve/route.ts
+++ b/web/src/app/api/projects/[id]/approve/route.ts
@@ -1,4 +1,4 @@
-import { projectsCol } from "@/lib/db";
+import { projectsCol, moderationLogCol, nextId, usersCol } from "@/lib/db";
 import { getAuthUser } from "@/lib/auth";
 export const dynamic = "force-dynamic";
 
@@ -20,9 +20,32 @@ export async function PUT(
     const body = await request.json().catch(() => ({}));
     const featured = body.featured ? 1 : 0;
     const status = featured ? "featured" : "approved";
+    const action = featured ? "feature" : "approve";
 
     await ref.update({ status, featured, updated_at: new Date().toISOString() });
     const updated = await ref.get();
+
+    // Fetch admin user details for logging
+    const adminDoc = await usersCol.ref.doc(String(auth.userId)).get();
+    const adminData = adminDoc.exists ? adminDoc.data()! : null;
+
+    // Log moderation action
+    const logId = await nextId("moderation_log");
+    const projectData = updated.data()!;
+    await moderationLogCol.ref.doc(String(logId)).set({
+      numericId: logId,
+      admin_id: auth.userId,
+      admin_username: adminData?.username || "unknown",
+      project_id: projectData.numericId,
+      project_name: projectData.name,
+      action,
+      action_details: {
+        featured: body.featured || false,
+        previous_status: doc.data()!.status,
+      },
+      created_at: new Date().toISOString(),
+    });
+
     return Response.json({ project: { ...updated.data(), id: updated.data()!.numericId } });
   } catch (err) {
     console.error("Approve error:", err);

--- a/web/src/app/api/projects/[id]/delist/route.ts
+++ b/web/src/app/api/projects/[id]/delist/route.ts
@@ -1,4 +1,4 @@
-import { projectsCol } from "@/lib/db";
+import { projectsCol, moderationLogCol, nextId, usersCol } from "@/lib/db";
 import { getAuthUser } from "@/lib/auth";
 export const dynamic = "force-dynamic";
 
@@ -25,6 +25,28 @@ export async function PUT(
       updated_at: new Date().toISOString(),
     });
     const updated = await ref.get();
+
+    // Fetch admin user details for logging
+    const adminDoc = await usersCol.ref.doc(String(auth.userId)).get();
+    const adminData = adminDoc.exists ? adminDoc.data()! : null;
+
+    // Log moderation action
+    const logId = await nextId("moderation_log");
+    const projectData = updated.data()!;
+    await moderationLogCol.ref.doc(String(logId)).set({
+      numericId: logId,
+      admin_id: auth.userId,
+      admin_username: adminData?.username || "unknown",
+      project_id: projectData.numericId,
+      project_name: projectData.name,
+      action: "delist",
+      action_details: {
+        reason: body.reason || "Delisted by admin",
+        previous_status: doc.data()!.status,
+      },
+      created_at: new Date().toISOString(),
+    });
+
     return Response.json({ project: { ...updated.data(), id: updated.data()!.numericId } });
   } catch (err) {
     console.error("Delist error:", err);

--- a/web/src/app/api/projects/[id]/reject/route.ts
+++ b/web/src/app/api/projects/[id]/reject/route.ts
@@ -1,4 +1,4 @@
-import { projectsCol } from "@/lib/db";
+import { projectsCol, moderationLogCol, nextId, usersCol } from "@/lib/db";
 import { getAuthUser } from "@/lib/auth";
 export const dynamic = "force-dynamic";
 
@@ -24,6 +24,28 @@ export async function PUT(
       updated_at: new Date().toISOString(),
     });
     const updated = await ref.get();
+
+    // Fetch admin user details for logging
+    const adminDoc = await usersCol.ref.doc(String(auth.userId)).get();
+    const adminData = adminDoc.exists ? adminDoc.data()! : null;
+
+    // Log moderation action
+    const logId = await nextId("moderation_log");
+    const projectData = updated.data()!;
+    await moderationLogCol.ref.doc(String(logId)).set({
+      numericId: logId,
+      admin_id: auth.userId,
+      admin_username: adminData?.username || "unknown",
+      project_id: projectData.numericId,
+      project_name: projectData.name,
+      action: "reject",
+      action_details: {
+        reason: body.reason || null,
+        previous_status: doc.data()!.status,
+      },
+      created_at: new Date().toISOString(),
+    });
+
     return Response.json({ project: { ...updated.data(), id: updated.data()!.numericId } });
   } catch (err) {
     console.error("Reject error:", err);

--- a/web/src/app/profile/page.tsx
+++ b/web/src/app/profile/page.tsx
@@ -5,6 +5,7 @@ import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { z } from "zod";
 import { useAuth } from "@/context/AuthContext";
+import { useQuery } from "@tanstack/react-query";
 import Link from "next/link";
 import {
   Form,
@@ -52,12 +53,34 @@ const profileSchema = z.object({
 
 type ProfileValues = z.infer<typeof profileSchema>;
 
+function useMaintainerStats(userId: number | undefined, token: string | null, isAdmin: boolean) {
+  return useQuery({
+    queryKey: ["maintainer-stats", userId],
+    queryFn: async () => {
+      if (!userId || !token || !isAdmin) return null;
+      const res = await fetch(`/api/admin/maintainer-stats/${userId}`, {
+        headers: { Authorization: `Bearer ${token}` },
+      });
+      if (!res.ok) throw new Error("Failed to fetch stats");
+      const data = await res.json();
+      return data.stats;
+    },
+    enabled: !!userId && !!token && isAdmin,
+  });
+}
+
 export default function ProfilePage() {
   const { user, token, refreshUser } = useAuth();
   const [success, setSuccess] = useState("");
   const [error, setError] = useState("");
   const [walletLoading, setWalletLoading] = useState(false);
   const [walletError, setWalletError] = useState("");
+  
+  const { data: maintainerStats, isLoading: statsLoading } = useMaintainerStats(
+    user?.userId,
+    token,
+    user?.role === "admin"
+  );
 
   const form = useForm<ProfileValues>({
     resolver: zodResolver(profileSchema),
@@ -246,6 +269,49 @@ export default function ProfilePage() {
           </div>
         )}
       </div>
+
+      {/* Maintainer Stats Section (Admin Only) */}
+      {user.role === "admin" && (
+        <div className="glass rounded-2xl p-6 mb-6 animate-in animate-in-delay-1">
+          <div className="flex items-center gap-3 mb-4">
+            <div className="w-10 h-10 rounded-xl bg-gradient-to-br from-solar/30 to-aurora/30 border border-solar/20 flex items-center justify-center">
+              <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="var(--solar-bright)" strokeWidth="2">
+                <path d="M12 20h9" />
+                <path d="M16.5 3.5a2.121 2.121 0 0 1 3 3L7 19l-4 1 1-4L16.5 3.5z" />
+              </svg>
+            </div>
+            <div>
+              <h2 className="font-semibold text-lg text-starlight">Moderation Activity</h2>
+              <p className="text-xs text-ash">Your project review and moderation statistics</p>
+            </div>
+          </div>
+
+          {statsLoading ? (
+            <div className="skeleton h-24 rounded-xl" />
+          ) : maintainerStats ? (
+            <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+              <div className="bg-stardust/30 rounded-xl p-4 text-center">
+                <p className="text-2xl font-bold text-starlight">{maintainerStats.total_reviews}</p>
+                <p className="text-xs text-ash uppercase tracking-wider mt-1">Total Reviews</p>
+              </div>
+              <div className="bg-aurora/10 rounded-xl p-4 text-center">
+                <p className="text-2xl font-bold text-aurora-bright">{maintainerStats.approvals}</p>
+                <p className="text-xs text-ash uppercase tracking-wider mt-1">Approvals</p>
+              </div>
+              <div className="bg-supernova/10 rounded-xl p-4 text-center">
+                <p className="text-2xl font-bold text-supernova">{maintainerStats.rejections}</p>
+                <p className="text-xs text-ash uppercase tracking-wider mt-1">Rejections</p>
+              </div>
+              <div className="bg-solar/10 rounded-xl p-4 text-center">
+                <p className="text-2xl font-bold text-solar-bright">{maintainerStats.features}</p>
+                <p className="text-xs text-ash uppercase tracking-wider mt-1">Featured</p>
+              </div>
+            </div>
+          ) : (
+            <p className="text-sm text-ash">No moderation activity recorded yet.</p>
+          )}
+        </div>
+      )}
 
       {/* Profile Form */}
       <div className="glass rounded-2xl p-8 animate-in animate-in-delay-2">

--- a/web/src/lib/db.ts
+++ b/web/src/lib/db.ts
@@ -26,6 +26,11 @@ export const financialSnapshotsCol = {
 		return col("financial_snapshots");
 	},
 };
+export const moderationLogCol = {
+	get ref() {
+		return col("moderation_log");
+	},
+};
 
 // Auto-incrementing numeric ID
 export async function nextId(collection: string): Promise<number> {


### PR DESCRIPTION
- Add moderation_log table to Supabase schema
- Add moderationLogCol to Firestore db.ts
- Update approve/reject/delist endpoints to log admin actions
- Create API endpoints for fetching maintainer stats
- Add maintainer stats display to profile page (admin only)
- Add leaderboard tab to admin dashboard with ranked maintainers
- Track approvals, rejections, features, and delists per maintainer