### PR TITLE
feat: add error states across all async views (#211)

### DIFF
--- a/web/src/app/admin/page.tsx
+++ b/web/src/app/admin/page.tsx
@@ -5,6 +5,7 @@ import { useAuth } from "@/context/AuthContext";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import Link from "next/link";
 import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/components/ui/tabs";
+import { ErrorState } from "@/components/ui/async-states";
 import {
   ON_CHAIN_ENABLED,
   explorerTxUrl,
@@ -993,10 +994,10 @@ export default function AdminPage() {
   const action = useProjectAction(token);
   const [search, setSearch] = useState("");
 
-  const { data: pending = [], isLoading: pendingLoading } = usePendingProjects(token);
-  const { data: approved = [], isLoading: approvedLoading } = useAdminProjects("approved", token);
-  const { data: featured = [], isLoading: featuredLoading } = useAdminProjects("featured", token);
-  const { data: all = [], isLoading: allLoading } = useAdminProjects(null, token);
+  const { data: pending = [], isLoading: pendingLoading, isError: pendingError, refetch: refetchPending } = usePendingProjects(token);
+  const { data: approved = [], isLoading: approvedLoading, isError: approvedError, refetch: refetchApproved } = useAdminProjects("approved", token);
+  const { data: featured = [], isLoading: featuredLoading, isError: featuredError, refetch: refetchFeatured } = useAdminProjects("featured", token);
+  const { data: all = [], isLoading: allLoading, isError: allError, refetch: refetchAll } = useAdminProjects(null, token);
 
   const filteredPending = filterProjects(pending, search);
   const filteredApproved = filterProjects(approved, search);
@@ -1149,6 +1150,8 @@ export default function AdminPage() {
           <TabsContent value="pending">
             {pendingLoading ? (
               <Skeletons />
+            ) : pendingError ? (
+              <ErrorState message="Failed to load pending projects." onRetry={() => refetchPending()} />
             ) : filteredPending.length > 0 ? (
               <div className="space-y-4">
                 {filteredPending.map((p) => (
@@ -1172,6 +1175,8 @@ export default function AdminPage() {
           <TabsContent value="approved">
             {approvedLoading ? (
               <Skeletons />
+            ) : approvedError ? (
+              <ErrorState message="Failed to load approved projects." onRetry={() => refetchApproved()} />
             ) : filteredApproved.length > 0 ? (
               <div className="space-y-2">
                 {filteredApproved.map((p) => (
@@ -1197,6 +1202,8 @@ export default function AdminPage() {
           <TabsContent value="featured">
             {featuredLoading ? (
               <Skeletons />
+            ) : featuredError ? (
+              <ErrorState message="Failed to load featured projects." onRetry={() => refetchFeatured()} />
             ) : filteredFeatured.length > 0 ? (
               <div className="space-y-2">
                 {filteredFeatured.map((p) => (
@@ -1220,6 +1227,8 @@ export default function AdminPage() {
           <TabsContent value="rejected">
             {allLoading ? (
               <Skeletons />
+            ) : allError ? (
+              <ErrorState message="Failed to load projects." onRetry={() => refetchAll()} />
             ) : rejectedCount > 0 ? (
               <div className="space-y-2">
                 {filteredAll
@@ -1247,6 +1256,8 @@ export default function AdminPage() {
           <TabsContent value="all">
             {allLoading ? (
               <Skeletons count={5} />
+            ) : allError ? (
+              <ErrorState message="Failed to load projects." onRetry={() => refetchAll()} />
             ) : filteredAll.length > 0 ? (
               <div className="space-y-2">
                 {filteredAll.map((p) => (

--- a/web/src/app/explore/page.tsx
+++ b/web/src/app/explore/page.tsx
@@ -3,6 +3,7 @@
 import {useEffect, useState, useCallback, Suspense} from "react";
 import {useRouter, useSearchParams, usePathname} from "next/navigation";
 import ProjectCard from "@/components/ProjectCard";
+import {ErrorState} from "@/components/ui/async-states";
 
 const CATEGORIES = [
 	"All",
@@ -66,9 +67,11 @@ function ExplorePageContent() {
 		() => searchParams.get("substantial") === "true",
 	);
 	const [loading, setLoading] = useState(true);
+	const [error, setError] = useState(false);
 
 	const fetchProjects = useCallback(async () => {
 		setLoading(true);
+		setError(false);
 		const params = new URLSearchParams();
 		if (category !== "All") params.set("category", category.toLowerCase());
 		if (search) params.set("search", search);
@@ -83,7 +86,7 @@ function ExplorePageContent() {
 			setProjects(data.projects || []);
 			setPagination((prev) => ({...prev, ...data.pagination}));
 		} catch {
-			setProjects([]);
+			setError(true);
 		}
 		setLoading(false);
 	}, [category, search, sort, substantialOnly, pagination.page]);
@@ -220,6 +223,11 @@ function ExplorePageContent() {
 						<div key={i} className="skeleton h-56 rounded-2xl" />
 					))}
 				</div>
+			) : error ? (
+				<ErrorState
+					message="Failed to load projects. Check your connection and try again."
+					onRetry={fetchProjects}
+				/>
 			) : projects.length > 0 ? (
 				<>
 					<div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">

--- a/web/src/app/my-projects/page.tsx
+++ b/web/src/app/my-projects/page.tsx
@@ -3,6 +3,7 @@
 import {useEffect, useState} from "react";
 import {useAuth} from "@/context/AuthContext";
 import Link from "next/link";
+import {ErrorState} from "@/components/ui/async-states";
 
 interface Project {
 	id: number;
@@ -29,20 +30,24 @@ export default function MyProjectsPage() {
 	const {user, token} = useAuth();
 	const [projects, setProjects] = useState<Project[]>([]);
 	const [loading, setLoading] = useState(true);
+	const [error, setError] = useState(false);
+	const [retryCount, setRetryCount] = useState(0);
 
 	useEffect(() => {
 		if (!token) {
 			setLoading(false);
 			return;
 		}
+		setLoading(true);
+		setError(false);
 		fetch("/api/projects/my", {
 			headers: {Authorization: `Bearer ${token}`},
 		})
 			.then((r) => r.json())
 			.then((data) => setProjects(data.projects || []))
-			.catch(() => {})
+			.catch(() => setError(true))
 			.finally(() => setLoading(false));
-	}, [token]);
+	}, [token, retryCount]);
 
 	if (!user) {
 		return (
@@ -97,6 +102,11 @@ export default function MyProjectsPage() {
 						<div key={i} className="skeleton h-28 rounded-2xl" />
 					))}
 				</div>
+			) : error ? (
+				<ErrorState
+					message="Failed to load your projects. Check your connection and try again."
+					onRetry={() => setRetryCount((c) => c + 1)}
+				/>
 			) : projects.length > 0 ? (
 				<div className="space-y-4 animate-in animate-in-delay-1">
 					{projects.map((project) => (

--- a/web/src/app/projects/[slug]/page.tsx
+++ b/web/src/app/projects/[slug]/page.tsx
@@ -4,6 +4,7 @@ import {useEffect, useState, use} from "react";
 import {useAuth} from "@/context/AuthContext";
 import StarRating from "@/components/StarRating";
 import Link from "next/link";
+import {ErrorState} from "@/components/ui/async-states";
 import {
 	ON_CHAIN_ENABLED,
 	rateProjectOnChain,
@@ -111,6 +112,8 @@ export default function ProjectDetailPage({
 	const [averages, setAverages] = useState<Averages | null>(null);
 	const [financials, setFinancials] = useState<FinancialSummary | null>(null);
 	const [loading, setLoading] = useState(true);
+	const [fetchError, setFetchError] = useState(false);
+	const [attempt, setAttempt] = useState(0);
 	const [activeTab, setActiveTab] = useState<
 		"overview" | "ratings" | "financials"
 	>("overview");
@@ -136,6 +139,8 @@ export default function ProjectDetailPage({
 	const [lastTxHash, setLastTxHash] = useState<string | null>(null);
 
 	useEffect(() => {
+		setFetchError(false);
+		setLoading(true);
 		fetch(`/api/projects/${slug}`)
 			.then((r) => r.json())
 			.then((data) => {
@@ -143,9 +148,9 @@ export default function ProjectDetailPage({
 				setRatings(data.ratings || []);
 				setAverages(data.averages);
 			})
-			.catch(() => {})
+			.catch(() => setFetchError(true))
 			.finally(() => setLoading(false));
-	}, [slug]);
+	}, [slug, attempt]);
 
 	useEffect(() => {
 		if (project?.stellar_account_id) {
@@ -258,6 +263,17 @@ export default function ProjectDetailPage({
 				<div className="skeleton h-8 w-64 mb-4 rounded-lg" />
 				<div className="skeleton h-4 w-96 mb-8 rounded-lg" />
 				<div className="skeleton h-64 rounded-2xl" />
+			</div>
+		);
+	}
+
+	if (fetchError) {
+		return (
+			<div className="max-w-5xl mx-auto px-4 py-12">
+				<ErrorState
+					message="Failed to load this project. Check your connection and try again."
+					onRetry={() => setAttempt((a) => a + 1)}
+				/>
 			</div>
 		);
 	}

--- a/web/src/app/queue/page.tsx
+++ b/web/src/app/queue/page.tsx
@@ -2,6 +2,7 @@
 
 import { useQuery } from "@tanstack/react-query";
 import Link from "next/link";
+import { ErrorState } from "@/components/ui/async-states";
 
 interface QueueProject {
   id: number;
@@ -29,7 +30,7 @@ function timeAgo(dateStr: string) {
 }
 
 export default function QueuePage() {
-  const { data, isLoading } = useQuery<{ projects: QueueProject[]; total: number }>({
+  const { data, isLoading, isError, refetch } = useQuery<{ projects: QueueProject[]; total: number }>({
     queryKey: ["project-queue"],
     queryFn: () => fetch("/api/projects/queue").then((r) => r.json()),
     refetchInterval: 30000,
@@ -76,6 +77,11 @@ export default function QueuePage() {
             <div key={i} className="skeleton h-32 rounded-2xl" />
           ))}
         </div>
+      ) : isError ? (
+        <ErrorState
+          message="Failed to load the approval queue. Check your connection and try again."
+          onRetry={() => refetch()}
+        />
       ) : projects.length > 0 ? (
         <div className="space-y-4 animate-in animate-in-delay-2">
           {projects.map((project, idx) => (

--- a/web/src/components/ui/async-states.tsx
+++ b/web/src/components/ui/async-states.tsx
@@ -1,0 +1,35 @@
+export function ErrorState({
+	title = "Something went wrong",
+	message = "We couldn't load this content. Please try again.",
+	onRetry,
+}: {
+	title?: string;
+	message?: string;
+	onRetry?: () => void;
+}) {
+	return (
+		<div className="glass rounded-2xl p-12 text-center">
+			<div className="w-16 h-16 mx-auto mb-4 rounded-2xl bg-supernova/10 border border-supernova/20 flex items-center justify-center">
+				<svg
+					width="28"
+					height="28"
+					viewBox="0 0 24 24"
+					fill="none"
+					stroke="var(--supernova)"
+					strokeWidth="1.5"
+				>
+					<circle cx="12" cy="12" r="10" />
+					<line x1="12" y1="8" x2="12" y2="12" />
+					<line x1="12" y1="16" x2="12.01" y2="16" />
+				</svg>
+			</div>
+			<h3 className="font-semibold text-lg text-moonlight mb-2">{title}</h3>
+			<p className="text-ash mb-6">{message}</p>
+			{onRetry && (
+				<button onClick={onRetry} className="btn-ghost text-sm">
+					Try again
+				</button>
+			)}
+		</div>
+	);
+}


### PR DESCRIPTION
Create shared ErrorState component and wire it into explore,
my-projects, queue, project-detail, and admin tabs. Each view
now tracks fetch failures and surfaces a "Try again" button
instead of silently swallowing errors or falling through to
the empty state.
close #211