### PR TITLE
feat: Rate limiting on auth + submission endpoints

### DIFF
--- a/web/scripts/test-rate-limit.ts
+++ b/web/scripts/test-rate-limit.ts
@@ -1,0 +1,55 @@
+import { checkRateLimit, getClientIdentifier } from "../src/lib/rateLimit";
+
+function runTests() {
+  console.log("--- Starting Rate Limiting Unit Tests ---");
+
+  const key = "test:ip:127.0.0.1:auth";
+  const limit = 5;
+  const windowMs = 60 * 1000;
+
+  // 1. Send 5 requests (should succeed)
+  for (let i = 1; i <= limit; i++) {
+    const res = checkRateLimit(key, limit, windowMs);
+    console.log(`Request ${i}: success=${res.success}, remaining=${res.remaining}`);
+    if (!res.success) {
+      console.error(`FAILED: Request ${i} should have succeeded!`);
+      process.exit(1);
+    }
+  }
+
+  // 2. Send 6th request (should fail with 429 & retryAfter)
+  const throttled = checkRateLimit(key, limit, windowMs);
+  console.log(
+    `Request 6 (Throttled): success=${throttled.success}, remaining=${throttled.remaining}, retryAfter=${throttled.retryAfter}s`
+  );
+
+  if (throttled.success || throttled.retryAfter <= 0) {
+    console.error("FAILED: 6th request should have been throttled with retryAfter > 0!");
+    process.exit(1);
+  }
+
+  // 3. Test user identifier vs IP identifier
+  const reqDummy = new Request("http://localhost/api/auth/login", {
+    headers: { "x-forwarded-for": "203.0.113.195, 10.0.0.1" },
+  });
+
+  const ipId = getClientIdentifier(reqDummy, null);
+  const userId = getClientIdentifier(reqDummy, 42);
+
+  console.log(`Client Identifier (IP): ${ipId}`);
+  console.log(`Client Identifier (User): ${userId}`);
+
+  if (ipId !== "ip:203.0.113.195") {
+    console.error(`FAILED: Expected ip:203.0.113.195, got ${ipId}`);
+    process.exit(1);
+  }
+
+  if (userId !== "user:42") {
+    console.error(`FAILED: Expected user:42, got ${userId}`);
+    process.exit(1);
+  }
+
+  console.log("--- ALL RATE LIMITING TESTS PASSED ---");
+}
+
+runTests();

--- a/web/src/lib/rateLimit.ts
+++ b/web/src/lib/rateLimit.ts
@@ -1,0 +1,112 @@
+interface RateLimitResult {
+  success: boolean;
+  limit: number;
+  remaining: number;
+  reset: number; // Unix timestamp in seconds
+  retryAfter: number; // Seconds to wait
+}
+
+interface RateLimitRule {
+  limit: number;
+  windowMs: number;
+}
+
+export const RATE_LIMIT_RULES: Record<string, RateLimitRule> = {
+  auth: { limit: 5, windowMs: 60 * 1000 }, // 5 requests per 60s
+  projectSubmit: { limit: 5, windowMs: 10 * 60 * 1000 }, // 5 requests per 10m
+  ratings: { limit: 10, windowMs: 60 * 1000 }, // 10 requests per 60s
+};
+
+// Global in-memory store for rate limit timestamp windows
+const rateLimitMap = new Map<string, number[]>();
+let lastCleanup = Date.now();
+
+
+// Clean up expired keys periodically to prevent memory leaks.
+
+function cleanupStore(now: number) {
+  // Only cleanup once every 60 seconds
+  if (now - lastCleanup < 60 * 1000) return;
+  lastCleanup = now;
+
+  for (const [key, timestamps] of rateLimitMap.entries()) {
+    // remove key if newest timestamp is older than 10 minutes,
+    const newest = timestamps[timestamps.length - 1];
+    if (!newest || now - newest > 10 * 60 * 1000) {
+      rateLimitMap.delete(key);
+    }
+  }
+}
+
+// Check and record a rate limit attempt using a sliding window algorithm.
+
+export function checkRateLimit(
+  key: string,
+  limit: number,
+  windowMs: number
+): RateLimitResult {
+  const now = Date.now();
+  cleanupStore(now);
+
+  const windowStart = now - windowMs;
+  let timestamps = rateLimitMap.get(key) || [];
+
+  // Remove timestamps outside sliding window
+  timestamps = timestamps.filter((t) => t > windowStart);
+
+  if (timestamps.length >= limit) {
+    const oldestTimestamp = timestamps[0];
+    const resetMs = oldestTimestamp + windowMs;
+    const retryAfter = Math.max(1, Math.ceil((resetMs - now) / 1000));
+    const reset = Math.ceil(resetMs / 1000);
+
+    rateLimitMap.set(key, timestamps);
+
+    return {
+      success: false,
+      limit,
+      remaining: 0,
+      reset,
+      retryAfter,
+    };
+  }
+
+  timestamps.push(now);
+  rateLimitMap.set(key, timestamps);
+
+  const reset = Math.ceil((now + windowMs) / 1000);
+  const remaining = limit - timestamps.length;
+
+  return {
+    success: true,
+    limit,
+    remaining,
+    reset,
+    retryAfter: 0,
+  };
+}
+
+/**
+ * Extract client identifier from request headers (IP) or authenticated user payload.
+ */
+export function getClientIdentifier(
+  request: Request,
+  userId?: number | string | null
+): string {
+  if (userId) {
+    return `user:${userId}`;
+  }
+
+  const xff = request.headers.get("x-forwarded-for");
+  if (xff) {
+    const ip = xff.split(",")[0].trim();
+    if (ip) return `ip:${ip}`;
+  }
+
+  const realIp = request.headers.get("x-real-ip");
+  if (realIp) {
+    return `ip:${realIp.trim()}`;
+  }
+
+  return "ip:127.0.0.1";
+}

--- a/web/src/middleware.ts
+++ b/web/src/middleware.ts
@@ -1,0 +1,1 @@
+export { proxy as default, proxy as middleware, config } from "./proxy";

--- a/web/src/proxy.ts
+++ b/web/src/proxy.ts
@@ -1,8 +1,15 @@
 import { NextResponse } from "next/server";
 import type { NextRequest } from "next/server";
+import { verifyToken } from "@/lib/auth";
+import {
+  checkRateLimit,
+  getClientIdentifier,
+  RATE_LIMIT_RULES,
+} from "@/lib/rateLimit";
 
 export function proxy(request: NextRequest) {
   const { pathname } = request.nextUrl;
+  const method = request.method;
 
   const protectedApiRoutes = ["/api/projects/pending", "/api/projects/my"];
 
@@ -17,8 +24,68 @@ export function proxy(request: NextRequest) {
     }
   }
 
+  // Determine rate limiting rules for sensitive endpoints
+  let rateLimitConfig: { limit: number; windowMs: number; category: string } | null = null;
+
+  if (method === "POST" && pathname.startsWith("/api/auth/")) {
+    rateLimitConfig = { ...RATE_LIMIT_RULES.auth, category: "auth" };
+  } else if (method === "POST" && pathname === "/api/projects") {
+    rateLimitConfig = { ...RATE_LIMIT_RULES.projectSubmit, category: "projectSubmit" };
+  } else if (
+    (method === "POST" && pathname === "/api/ratings") ||
+    (method === "DELETE" && pathname.startsWith("/api/ratings/"))
+  ) {
+    rateLimitConfig = { ...RATE_LIMIT_RULES.ratings, category: "ratings" };
+  }
+
+  if (rateLimitConfig) {
+    let userId: number | null = null;
+    const authHeader = request.headers.get("Authorization");
+    if (authHeader?.startsWith("Bearer ")) {
+      const payload = verifyToken(authHeader.slice(7));
+      if (payload?.userId) {
+        userId = payload.userId;
+      }
+    }
+
+    const clientId = getClientIdentifier(request, userId);
+    const key = `${clientId}:${rateLimitConfig.category}`;
+
+    const rlResult = checkRateLimit(
+      key,
+      rateLimitConfig.limit,
+      rateLimitConfig.windowMs
+    );
+
+    if (!rlResult.success) {
+      return NextResponse.json(
+        {
+          error: "Too many requests. Please try again later.",
+          retryAfter: rlResult.retryAfter,
+        },
+        {
+          status: 429,
+          headers: {
+            "Retry-After": String(rlResult.retryAfter),
+            "X-RateLimit-Limit": String(rlResult.limit),
+            "X-RateLimit-Remaining": "0",
+            "X-RateLimit-Reset": String(rlResult.reset),
+          },
+        }
+      );
+    }
+
+    const response = NextResponse.next();
+    response.headers.set("X-RateLimit-Limit", String(rlResult.limit));
+    response.headers.set("X-RateLimit-Remaining", String(rlResult.remaining));
+    response.headers.set("X-RateLimit-Reset", String(rlResult.reset));
+    return response;
+  }
+
   return NextResponse.next();
 }
+
+export const middleware = proxy;
 
 export const config = {
   matcher: ["/api/:path*"],


### PR DESCRIPTION
Added basic backend rate limiting to authentication, project submission, and rating endpoints to deter spam, abuse, and brute-force attempts while keeping normal usage unaffected.

- Closes #217 

Changes
- Added a Sliding-Window Rate Limiter (web/src/lib/rateLimit.ts):

Implemented lightweight in-memory sliding-window rate limiting with automatic background memory cleanup.
Added support for per-IP limiting (unauthenticated auth endpoints) and per-user limiting (authenticated actions).
 - Configured endpoint rules:
Auth (POST /api/auth/*): 5 requests / 60 seconds
Project Submissions (POST /api/projects): 5 requests / 10 minutes
Ratings (POST /api/ratings, DELETE /api/ratings/*): 10 requests / 60 seconds
- Next.js Middleware Interceptor (web/src/proxy.ts & web/src/middleware.ts):

performs centralized rate limit checks across targeted routes.

- Verification Tests (web/scripts/test-rate-limit.ts):

<img width="669" height="278" alt="image" src="https://github.com/user-attachments/assets/6f58e177-2be0-4946-93b2-42b121774484" />
