### PR TITLE
feat: tag-based filtering and tag pages

### DIFF
--- a/web/src/app/api/projects/route.ts
+++ b/web/src/app/api/projects/route.ts
@@ -12,6 +12,7 @@ export async function GET(request: Request) {
 		const search = url.searchParams.get("search")?.toLowerCase();
 		const substantial = url.searchParams.get("substantial") === "true";
 		const sort = url.searchParams.get("sort") || "newest";
+		const tag = url.searchParams.get("tag")?.toLowerCase();
 		const page = Math.max(1, Number(url.searchParams.get("page")) || 1);
 		const limit = Math.min(
 			50,
@@ -38,13 +39,19 @@ export async function GET(request: Request) {
 			id: d.data().numericId,
 		}));
 
-		// Client-side search filtering (Firestore doesn't support LIKE)
+		// Client-side search and tag filtering (Firestore doesn't support LIKE or array-contains well dynamically here)
 		if (search) {
 			projects = projects.filter(
 				(p) =>
 					(p.name as string)?.toLowerCase().includes(search) ||
 					(p.description as string)?.toLowerCase().includes(search) ||
 					(p.tags as string)?.toLowerCase().includes(search),
+			);
+		}
+		
+		if (tag) {
+			projects = projects.filter(
+				(p) => (p.tags as string)?.toLowerCase().split(',').map(t => t.trim()).includes(tag)
 			);
 		}
 

--- a/web/src/app/explore/page.tsx
+++ b/web/src/app/explore/page.tsx
@@ -65,6 +65,7 @@ function ExplorePageContent() {
 	const [substantialOnly, setSubstantialOnly] = useState(
 		() => searchParams.get("substantial") === "true",
 	);
+	const tag = searchParams.get("tag");
 	const [loading, setLoading] = useState(true);
 
 	const fetchProjects = useCallback(async () => {
@@ -72,6 +73,7 @@ function ExplorePageContent() {
 		const params = new URLSearchParams();
 		if (category !== "All") params.set("category", category.toLowerCase());
 		if (search) params.set("search", search);
+		if (tag) params.set("tag", tag);
 		if (substantialOnly) params.set("substantial", "true");
 		params.set("sort", sort);
 		params.set("page", String(pagination.page));
@@ -86,7 +88,7 @@ function ExplorePageContent() {
 			setProjects([]);
 		}
 		setLoading(false);
-	}, [category, search, sort, substantialOnly, pagination.page]);
+	}, [category, search, tag, sort, substantialOnly, pagination.page]);
 
 	useEffect(() => {
 		fetchProjects();
@@ -100,6 +102,15 @@ function ExplorePageContent() {
 		const newParams = new URLSearchParams(searchParams.toString());
 		if (next) newParams.set("substantial", "true");
 		else newParams.delete("substantial");
+		router.replace(
+			newParams.toString() ? `${pathname}?${newParams}` : pathname,
+			{scroll: false},
+		);
+	};
+
+	const removeTag = () => {
+		const newParams = new URLSearchParams(searchParams.toString());
+		newParams.delete("tag");
 		router.replace(
 			newParams.toString() ? `${pathname}?${newParams}` : pathname,
 			{scroll: false},
@@ -194,7 +205,7 @@ function ExplorePageContent() {
 			</div>
 
 			{/* Category tabs */}
-			<div className="flex gap-2 overflow-x-auto pb-4 mb-8 animate-in animate-in-delay-2 scrollbar-none">
+			<div className="flex gap-2 overflow-x-auto pb-4 mb-4 animate-in animate-in-delay-2 scrollbar-none">
 				{CATEGORIES.map((cat) => (
 					<button
 						key={cat}
@@ -212,6 +223,26 @@ function ExplorePageContent() {
 					</button>
 				))}
 			</div>
+
+			{/* Active Tag */}
+			{tag && (
+				<div className="mb-8 animate-in flex items-center gap-2">
+					<span className="text-sm text-ash">Filtered by tag:</span>
+					<span className="inline-flex items-center gap-1.5 px-3 py-1 rounded-lg bg-aurora/10 text-aurora-bright font-medium text-sm border border-aurora/20">
+						{tag}
+						<button
+							onClick={removeTag}
+							className="hover:text-white transition-colors"
+							aria-label="Remove tag filter"
+						>
+							<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+								<line x1="18" y1="6" x2="6" y2="18" />
+								<line x1="6" y1="6" x2="18" y2="18" />
+							</svg>
+						</button>
+					</span>
+				</div>
+			)}
 
 			{/* Results */}
 			{loading ? (

--- a/web/src/components/ProjectCard.tsx
+++ b/web/src/components/ProjectCard.tsx
@@ -39,10 +39,10 @@ export default function ProjectCard({ project, index = 0 }: ProjectCardProps) {
   const tags = project.tags ? project.tags.split(",").slice(0, 3) : [];
 
   return (
-    <Link
-      href={`/projects/${project.slug}`}
+    <div
       className={`group relative glass glass-hover rounded-2xl p-6 flex flex-col gap-4 transition-all duration-300 animate-in animate-in-delay-${Math.min(index + 1, 5)}`}
     >
+      <Link href={`/projects/${project.slug}`} className="absolute inset-0 z-0" aria-label={`View ${project.name}`} />
       {/* Featured badge */}
       {project.featured === 1 && (
         <div className="absolute -top-2 -right-2 featured-badge bg-solar/20 text-solar-bright text-xs font-bold px-2.5 py-1 rounded-full border border-solar/30 flex items-center gap-1">
@@ -80,14 +80,15 @@ export default function ProjectCard({ project, index = 0 }: ProjectCardProps) {
 
       {/* Tags */}
       {tags.length > 0 && (
-        <div className="flex flex-wrap gap-1.5">
+        <div className="flex flex-wrap gap-1.5 relative z-10">
           {tags.map((tag) => (
-            <span
+            <Link
               key={tag}
-              className="text-[11px] px-2 py-0.5 rounded-md bg-stardust/80 text-ash font-medium"
+              href={`/explore?tag=${encodeURIComponent(tag.trim())}`}
+              className="text-[11px] px-2 py-0.5 rounded-md bg-stardust/80 text-ash font-medium hover:text-aurora-bright hover:bg-aurora/10 transition-colors"
             >
               {tag.trim()}
-            </span>
+            </Link>
           ))}
         </div>
       )}
@@ -141,6 +142,6 @@ export default function ProjectCard({ project, index = 0 }: ProjectCardProps) {
           )}
         </div>
       </div>
-    </Link>
+    </div>
   );
 }


### PR DESCRIPTION
# Title: feat: Tag-based filtering and tag pages

## Description
Closes #207 

This PR implements tag-based filtering for projects in the explore page. It makes project tags clickable and filters the `Explore` view server-side when a tag is selected.

### Changes
*   **ProjectCard**: Replaced the outer `Link` wrapper with a `div` and added an invisible absolute `Link` to maintain the clickability of the entire card while allowing nested interactive elements. Updated project tags to be clickable `Link` components that route to `/explore?tag=...`.
*   **API Route (`/api/projects/route.ts`)**: Extracted the `tag` query parameter and updated the filtering logic to properly filter projects that contain the specified tag in their `tags` string.
*   **Explore Page (`/explore/page.tsx`)**: 
    *   Reads the `tag` parameter from the URL using `useSearchParams`.
    *   Passes the `tag` parameter to the backend API.
    *   Added a visual indicator (chip) at the top of the list when a tag is active, along with a button to easily clear the tag filter and return to all results.

### Acceptance Criteria
- [x] Clicking a tag filters to projects with that tag
