### PR TITLE
feat(auth): centralize RBAC permissions (#235)

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -6,7 +6,8 @@
 		"dev": "next dev --experimental-https",
 		"build": "next build",
 		"start": "next start",
-		"lint": "eslint"
+		"lint": "eslint",
+		"test": "node --test --experimental-strip-types --test-isolation=none src/lib/auth.test.mjs"
 	},
 	"dependencies": {
 		"@hookform/resolvers": "^5.2.2",

--- a/web/src/app/api/admin/projects/route.ts
+++ b/web/src/app/api/admin/projects/route.ts
@@ -1,10 +1,9 @@
 import { projectsCol, usersCol, ratingsCol } from "@/lib/db";
-import { getAuthUser, hasMinRole } from "@/lib/auth";
+import { requireRole } from "@/lib/auth";
 export const dynamic = "force-dynamic";
 
 export async function GET(request: Request) {
-  const auth = getAuthUser(request);
-  if (!auth || !hasMinRole(auth.role, "admin")) {
+  if (!requireRole(request, "maintainer")) {
     return Response.json({ error: "Forbidden" }, { status: 403 });
   }
 

--- a/web/src/app/api/projects/[id]/approve/route.ts
+++ b/web/src/app/api/projects/[id]/approve/route.ts
@@ -1,5 +1,5 @@
 import { projectsCol } from "@/lib/db";
-import { getAuthUser, hasMinRole } from "@/lib/auth";
+import { can, requireRole } from "@/lib/auth";
 import { parseJsonBody } from "@/lib/validation/parse-body";
 import { featuredProjectSchema } from "@/lib/validation/schemas/featured";
 import { checkRateLimit, rateLimitExceededResponse } from "@/lib/rate-limit";
@@ -11,8 +11,8 @@ export async function PUT(
   request: Request,
   { params }: { params: Promise<{ id: string }> }
 ) {
-  const auth = getAuthUser(request);
-  if (!auth || !hasMinRole(auth.role, "admin")) {
+  const auth = requireRole(request, "maintainer");
+  if (!auth) {
     return Response.json({ error: "Forbidden" }, { status: 403 });
   }
 
@@ -26,6 +26,11 @@ export async function PUT(
 
   const parsed = await parseJsonBody(request, featuredProjectSchema);
   if (!parsed.success) return parsed.response;
+
+  const action = parsed.data.featured ? "feature" : "approve";
+  if (!can(auth.role, action)) {
+    return Response.json({ error: "Forbidden" }, { status: 403 });
+  }
 
   try {
     const featured = parsed.data.featured ? 1 : 0;

--- a/web/src/app/api/projects/[id]/delete/route.ts
+++ b/web/src/app/api/projects/[id]/delete/route.ts
@@ -1,13 +1,13 @@
 import { projectsCol, ratingsCol } from "@/lib/db";
-import { getAuthUser, hasMinRole } from "@/lib/auth";
+import { can, requireRole } from "@/lib/auth";
 export const dynamic = "force-dynamic";
 
 export async function DELETE(
   request: Request,
   { params }: { params: Promise<{ id: string }> }
 ) {
-  const auth = getAuthUser(request);
-  if (!auth || !hasMinRole(auth.role, "admin")) {
+  const auth = requireRole(request, "admin");
+  if (!auth || !can(auth.role, "delete")) {
     return Response.json({ error: "Forbidden" }, { status: 403 });
   }
 

--- a/web/src/app/api/projects/[id]/delist/route.ts
+++ b/web/src/app/api/projects/[id]/delist/route.ts
@@ -1,5 +1,5 @@
 import { projectsCol } from "@/lib/db";
-import { getAuthUser, hasMinRole } from "@/lib/auth";
+import { can, requireRole } from "@/lib/auth";
 import { parseJsonBody } from "@/lib/validation/parse-body";
 import { delistProjectSchema } from "@/lib/validation/schemas/featured";
 export const dynamic = "force-dynamic";
@@ -8,8 +8,8 @@ export async function PUT(
   request: Request,
   { params }: { params: Promise<{ id: string }> }
 ) {
-  const auth = getAuthUser(request);
-  if (!auth || !hasMinRole(auth.role, "admin")) {
+  const auth = requireRole(request, "maintainer");
+  if (!auth || !can(auth.role, "delist")) {
     return Response.json({ error: "Forbidden" }, { status: 403 });
   }
 

--- a/web/src/app/api/projects/[id]/edit/route.ts
+++ b/web/src/app/api/projects/[id]/edit/route.ts
@@ -1,5 +1,5 @@
 import { projectsCol } from "@/lib/db";
-import { getAuthUser, hasMinRole } from "@/lib/auth";
+import { getAuthUser, requireRole } from "@/lib/auth";
 import { parseJsonBody } from "@/lib/validation/parse-body";
 import { editProjectSchema } from "@/lib/validation/schemas/projects";
 export const dynamic = "force-dynamic";
@@ -17,7 +17,7 @@ export async function PUT(
   if (!doc.exists) return Response.json({ error: "Project not found" }, { status: 404 });
 
   const project = doc.data()!;
-  if (project.user_id !== auth.userId && !hasMinRole(auth.role, "admin")) {
+  if (project.user_id !== auth.userId && !requireRole(request, "admin")) {
     return Response.json({ error: "Forbidden" }, { status: 403 });
   }
 

--- a/web/src/app/api/projects/[id]/reject/route.ts
+++ b/web/src/app/api/projects/[id]/reject/route.ts
@@ -1,5 +1,5 @@
 import { projectsCol } from "@/lib/db";
-import { getAuthUser, hasMinRole } from "@/lib/auth";
+import { can, requireRole } from "@/lib/auth";
 import { parseJsonBody } from "@/lib/validation/parse-body";
 import { rejectProjectSchema } from "@/lib/validation/schemas/featured";
 import { checkRateLimit, rateLimitExceededResponse } from "@/lib/rate-limit";
@@ -11,8 +11,8 @@ export async function PUT(
   request: Request,
   { params }: { params: Promise<{ id: string }> }
 ) {
-  const auth = getAuthUser(request);
-  if (!auth || !hasMinRole(auth.role, "admin")) {
+  const auth = requireRole(request, "maintainer");
+  if (!auth || !can(auth.role, "reject")) {
     return Response.json({ error: "Forbidden" }, { status: 403 });
   }
 

--- a/web/src/app/api/projects/pending/route.ts
+++ b/web/src/app/api/projects/pending/route.ts
@@ -1,10 +1,9 @@
 import { projectsCol, usersCol } from "@/lib/db";
-import { getAuthUser, hasMinRole } from "@/lib/auth";
+import { requireRole } from "@/lib/auth";
 export const dynamic = "force-dynamic";
 
 export async function GET(request: Request) {
-  const auth = getAuthUser(request);
-  if (!auth || !hasMinRole(auth.role, "admin")) {
+  if (!requireRole(request, "maintainer")) {
     return Response.json({ error: "Forbidden" }, { status: 403 });
   }
 

--- a/web/src/app/api/ratings/[id]/route.ts
+++ b/web/src/app/api/ratings/[id]/route.ts
@@ -1,5 +1,5 @@
 import { ratingsCol } from "@/lib/db";
-import { getAuthUser, hasMinRole } from "@/lib/auth";
+import { can, getAuthUser } from "@/lib/auth";
 export const dynamic = "force-dynamic";
 
 export async function DELETE(
@@ -15,7 +15,7 @@ export async function DELETE(
   if (!doc.exists) return Response.json({ error: "Rating not found" }, { status: 404 });
 
   const rating = doc.data()!;
-  if (rating.user_id !== auth.userId && !hasMinRole(auth.role, "admin")) {
+  if (rating.user_id !== auth.userId && !can(auth.role, "delete")) {
     return Response.json({ error: "Forbidden" }, { status: 403 });
   }
 

--- a/web/src/lib/auth.test.mjs
+++ b/web/src/lib/auth.test.mjs
@@ -1,0 +1,36 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { ACTIONS, can, requireRole, signToken } from "./auth.ts";
+
+const expectedPermissions = {
+  contributor: [],
+  maintainer: ["approve", "reject", "feature", "delist"],
+  admin: [...ACTIONS],
+};
+
+for (const [role, allowedActions] of Object.entries(expectedPermissions)) {
+  test(`${role} has the expected permissions`, () => {
+    for (const action of ACTIONS) {
+      assert.equal(can(role, action), allowedActions.includes(action), `${role}: ${action}`);
+    }
+  });
+}
+
+test("unknown roles and actions are denied", () => {
+  assert.equal(can("owner", "approve"), false);
+  assert.equal(can("admin", "unknown"), false);
+});
+
+test("requireRole enforces the role hierarchy", () => {
+  const requestFor = (role) =>
+    new Request("https://example.test", {
+      headers: { Authorization: `Bearer ${signToken({ userId: 1, role })}` },
+    });
+
+  assert.equal(requireRole(requestFor("contributor"), "maintainer"), null);
+  assert.equal(requireRole(requestFor("maintainer"), "maintainer")?.role, "maintainer");
+  assert.equal(requireRole(requestFor("admin"), "maintainer")?.role, "admin");
+  assert.equal(requireRole(requestFor("unknown"), "contributor"), null);
+  assert.equal(requireRole(new Request("https://example.test"), "contributor"), null);
+});

--- a/web/src/lib/auth.ts
+++ b/web/src/lib/auth.ts
@@ -1,10 +1,65 @@
 import bcrypt from "bcryptjs";
 import jwt from "jsonwebtoken";
-import { ROLES, hasMinRole } from "./roles";
+import { ROLES, hasMinRole, type Role } from "./roles.ts";
 
 const JWT_SECRET = process.env.JWT_SECRET || "stellar-wave-hub-dev-secret";
 
 export { ROLES, hasMinRole };
+export type { Role };
+
+export const ACTIONS = [
+  "approve",
+  "reject",
+  "feature",
+  "delete",
+  "delist",
+  "manage-users",
+] as const;
+export type Action = (typeof ACTIONS)[number];
+
+export type AuthUser = {
+  userId: number;
+  role: string;
+};
+
+export const PERMISSIONS: Readonly<Record<Role, Readonly<Record<Action, boolean>>>> = {
+  contributor: {
+    approve: false,
+    reject: false,
+    feature: false,
+    delete: false,
+    delist: false,
+    "manage-users": false,
+  },
+  maintainer: {
+    approve: true,
+    reject: true,
+    feature: true,
+    delete: false,
+    delist: true,
+    "manage-users": false,
+  },
+  admin: {
+    approve: true,
+    reject: true,
+    feature: true,
+    delete: true,
+    delist: true,
+    "manage-users": true,
+  },
+};
+
+function isRole(role: string): role is Role {
+  return role in ROLES;
+}
+
+function isAction(action: string): action is Action {
+  return ACTIONS.some((knownAction) => knownAction === action);
+}
+
+export function can(role: string, action: string): boolean {
+  return isRole(role) && isAction(action) && PERMISSIONS[role][action];
+}
 
 export async function hashPassword(password: string): Promise<string> {
   return bcrypt.hash(password, 12);
@@ -14,20 +69,29 @@ export async function comparePassword(password: string, hash: string): Promise<b
   return bcrypt.compare(password, hash);
 }
 
-export function signToken(payload: { userId: number; role: string }): string {
+export function signToken(payload: AuthUser): string {
   return jwt.sign(payload, JWT_SECRET, { expiresIn: "7d" });
 }
 
-export function verifyToken(token: string): { userId: number; role: string } | null {
+export function verifyToken(token: string): AuthUser | null {
   try {
-    return jwt.verify(token, JWT_SECRET) as { userId: number; role: string };
+    const payload = jwt.verify(token, JWT_SECRET) as Partial<AuthUser>;
+    if (typeof payload.userId !== "number" || typeof payload.role !== "string") {
+      return null;
+    }
+    return { userId: payload.userId, role: payload.role };
   } catch {
     return null;
   }
 }
 
-export function getAuthUser(request: Request): { userId: number; role: string } | null {
+export function getAuthUser(request: Request): AuthUser | null {
   const header = request.headers.get("Authorization");
   if (!header?.startsWith("Bearer ")) return null;
   return verifyToken(header.slice(7));
+}
+
+export function requireRole(request: Request, minRole: Role): AuthUser | null {
+  const auth = getAuthUser(request);
+  return auth && hasMinRole(auth.role, minRole) ? auth : null;
 }

--- a/web/tsconfig.json
+++ b/web/tsconfig.json
@@ -3,6 +3,7 @@
 		"target": "ES2017",
 		"lib": ["dom", "dom.iterable", "esnext"],
 		"allowJs": true,
+		"allowImportingTsExtensions": true,
 		"skipLibCheck": true,
 		"strict": true,
 		"noEmit": true,


### PR DESCRIPTION
## Summary

Closes #235.

Introduces a centralized role-based access-control system so API routes no longer hard-code admin role comparisons.

## Changes

- Added `requireRole(request, minRole)` for hierarchical role checks
- Added `can(role, action)` for action-level authorization
- Defined permissions for:
  - `approve`
  - `reject`
  - `feature`
  - `delete`
  - `delist`
  - `manage-users`
- Refactored project moderation, deletion, editing, listing, and rating routes
- Added deny-by-default handling for unknown roles and actions
- Added automated tests for contributor, maintainer, and admin permissions

## Permission matrix

| Role | Approve | Reject | Feature | Delete | Delist | Manage users |
|---|---:|---:|---:|---:|---:|---:|
| Contributor | No | No | No | No | No | No |
| Maintainer | Yes | Yes | Yes | No | Yes | No |
| Admin | Yes | Yes | Yes | Yes | Yes | Yes |

## Validation

- `npm test`
- Focused ESLint checks
- `npx tsc --noEmit`
- `npm run build`