### PR TITLE
feat: add rating helpfulness votes (#213)

### DIFF
--- a/web/data/supabase/007_add_rating_votes.sql
+++ b/web/data/supabase/007_add_rating_votes.sql
@@ -1,0 +1,33 @@
+-- Migration 007: Add rating_votes table
+-- One vote per user per rating, for marking reviews as helpful.
+
+begin;
+
+create table if not exists public.rating_votes (
+  "numericId" bigint primary key,
+  rating_id bigint not null,
+  user_id bigint not null,
+  created_at timestamptz not null default now(),
+  constraint rating_votes_rating_id_fkey
+    foreign key (rating_id)
+    references public.ratings ("numericId")
+    on delete cascade,
+  constraint rating_votes_user_id_fkey
+    foreign key (user_id)
+    references public.users ("numericId")
+    on delete cascade
+);
+
+create unique index if not exists rating_votes_rating_user_unique_idx on public.rating_votes (rating_id, user_id);
+create index if not exists rating_votes_rating_id_idx on public.rating_votes (rating_id);
+create index if not exists rating_votes_user_id_idx on public.rating_votes (user_id);
+
+-- Seed counter used by nextId()
+insert into public.counters (name, value)
+values ('rating_votes', 0)
+on conflict (name) do nothing;
+
+-- RLS: table is backend-only.
+alter table public.rating_votes enable row level security;
+
+commit;

--- a/web/data/supabase/schema.sql
+++ b/web/data/supabase/schema.sql
@@ -116,12 +116,32 @@ create table if not exists public.financial_snapshots (
 create index if not exists financial_snapshots_project_id_idx on public.financial_snapshots (project_id);
 create index if not exists financial_snapshots_created_at_idx on public.financial_snapshots (created_at desc);
 
+create table if not exists public.rating_votes (
+  "numericId" bigint primary key,
+  rating_id bigint not null,
+  user_id bigint not null,
+  created_at timestamptz not null default now(),
+  constraint rating_votes_rating_id_fkey
+    foreign key (rating_id)
+    references public.ratings ("numericId")
+    on delete cascade,
+  constraint rating_votes_user_id_fkey
+    foreign key (user_id)
+    references public.users ("numericId")
+    on delete cascade
+);
+
+create unique index if not exists rating_votes_rating_user_unique_idx on public.rating_votes (rating_id, user_id);
+create index if not exists rating_votes_rating_id_idx on public.rating_votes (rating_id);
+create index if not exists rating_votes_user_id_idx on public.rating_votes (user_id);
+
 -- Seed counters used by nextId()
 insert into public.counters (name, value)
 values
   ('users', 0),
   ('projects', 0),
-  ('ratings', 0)
+  ('ratings', 0),
+  ('rating_votes', 0)
 on conflict (name) do nothing;
 
 commit;

--- a/web/src/app/api/projects/[id]/route.ts
+++ b/web/src/app/api/projects/[id]/route.ts
@@ -1,4 +1,5 @@
 import { projectsCol, usersCol, ratingsCol } from "@/lib/db";
+import { getSupabase } from "@/lib/firebase";
 export const dynamic = "force-dynamic";
 
 export async function GET(
@@ -53,6 +54,31 @@ export async function GET(
       return { ...r, id: r.numericId ?? d.id, username };
     })
   );
+
+  // Attach helpful vote counts
+  const ratingIds = ratings.map((r) => r.numericId as number).filter(Boolean);
+  if (ratingIds.length > 0) {
+    const supabase = getSupabase();
+    const { data: voteRows } = await supabase
+      .from("rating_votes")
+      .select("rating_id")
+      .in("rating_id", ratingIds);
+
+    const countMap = new Map<number, number>();
+    for (const v of voteRows ?? []) {
+      const rid = Number(v.rating_id);
+      countMap.set(rid, (countMap.get(rid) ?? 0) + 1);
+    }
+
+    for (const r of ratings) {
+      const rid = r.numericId as number | undefined;
+      r.helpful_count = rid ? (countMap.get(rid) ?? 0) : 0;
+    }
+  } else {
+    for (const r of ratings) {
+      r.helpful_count = 0;
+    }
+  }
 
   // Compute averages
   const scores = ratings.map((r) => r.score as number);

--- a/web/src/app/api/rating-votes/route.ts
+++ b/web/src/app/api/rating-votes/route.ts
@@ -1,0 +1,104 @@
+import { ratingVotesCol, nextId } from "@/lib/db";
+import { getAuthUser } from "@/lib/auth";
+import { getSupabase } from "@/lib/firebase";
+export const dynamic = "force-dynamic";
+
+export async function POST(request: Request) {
+  const auth = getAuthUser(request);
+  if (!auth) return Response.json({ error: "Unauthorized" }, { status: 401 });
+
+  let body: { rating_id?: number };
+  try {
+    body = await request.json();
+  } catch {
+    return Response.json({ error: "Invalid JSON" }, { status: 400 });
+  }
+
+  const { rating_id } = body;
+  if (!rating_id || typeof rating_id !== "number") {
+    return Response.json({ error: "rating_id is required" }, { status: 400 });
+  }
+
+  try {
+    const supabase = getSupabase();
+
+    // Check if vote already exists
+    const { data: existing } = await supabase
+      .from("rating_votes")
+      .select("numericId")
+      .eq("rating_id", rating_id)
+      .eq("user_id", auth.userId)
+      .maybeSingle();
+
+    let voted: boolean;
+
+    if (existing) {
+      // Remove vote
+      await supabase
+        .from("rating_votes")
+        .delete()
+        .eq("numericId", existing.numericId);
+      voted = false;
+    } else {
+      // Add vote
+      const numericId = await nextId("rating_votes");
+      await ratingVotesCol.ref.doc(String(numericId)).set({
+        numericId,
+        rating_id,
+        user_id: auth.userId,
+        created_at: new Date().toISOString(),
+      });
+      voted = true;
+    }
+
+    // Get updated count
+    const { count } = await supabase
+      .from("rating_votes")
+      .select("*", { count: "exact", head: true })
+      .eq("rating_id", rating_id);
+
+    return Response.json({ voted, helpful_count: count ?? 0 });
+  } catch (err) {
+    console.error("Rating vote error:", err);
+    return Response.json({ error: "Internal server error" }, { status: 500 });
+  }
+}
+
+export async function GET(request: Request) {
+  const auth = getAuthUser(request);
+  if (!auth) return Response.json({ error: "Unauthorized" }, { status: 401 });
+
+  const url = new URL(request.url);
+  const ratingIdsParam = url.searchParams.get("rating_ids");
+  if (!ratingIdsParam) {
+    return Response.json({ votes: {} });
+  }
+
+  const ratingIds = ratingIdsParam
+    .split(",")
+    .map(Number)
+    .filter((id) => !isNaN(id));
+
+  if (ratingIds.length === 0) {
+    return Response.json({ votes: {} });
+  }
+
+  try {
+    const supabase = getSupabase();
+    const { data: userVotes } = await supabase
+      .from("rating_votes")
+      .select("rating_id")
+      .in("rating_id", ratingIds)
+      .eq("user_id", auth.userId);
+
+    const votes: Record<number, boolean> = {};
+    for (const v of userVotes ?? []) {
+      votes[Number(v.rating_id)] = true;
+    }
+
+    return Response.json({ votes });
+  } catch (err) {
+    console.error("Rating votes fetch error:", err);
+    return Response.json({ error: "Internal server error" }, { status: 500 });
+  }
+}

--- a/web/src/app/projects/[slug]/page.tsx
+++ b/web/src/app/projects/[slug]/page.tsx
@@ -46,6 +46,7 @@ interface Rating {
 	username: string;
 	user_id: number;
 	created_at: string;
+	helpful_count?: number;
 }
 
 interface Averages {
@@ -134,6 +135,8 @@ export default function ProjectDetailPage({
 	const [ratingMsg, setRatingMsg] = useState("");
 	const [ratingStep, setRatingStep] = useState<"idle" | "onchain" | "saving">("idle");
 	const [lastTxHash, setLastTxHash] = useState<string | null>(null);
+	const [ratingSort, setRatingSort] = useState<"recent" | "helpful">("recent");
+	const [userVotes, setUserVotes] = useState<Record<number, boolean>>({});
 
 	useEffect(() => {
 		fetch(`/api/projects/${slug}`)
@@ -146,6 +149,21 @@ export default function ProjectDetailPage({
 			.catch(() => {})
 			.finally(() => setLoading(false));
 	}, [slug]);
+
+	const ratingIds = ratings.map((r) => r.id);
+
+	useEffect(() => {
+		if (!token || ratingIds.length === 0) {
+			setUserVotes({});
+			return;
+		}
+		fetch(`/api/rating-votes?rating_ids=${ratingIds.join(",")}`, {
+			headers: { Authorization: `Bearer ${token}` },
+		})
+			.then((r) => r.json())
+			.then((data) => setUserVotes(data.votes || {}))
+			.catch(() => setUserVotes({}));
+	}, [token, ratingIds.join(",")]);
 
 	useEffect(() => {
 		if (project?.stellar_account_id) {
@@ -251,6 +269,36 @@ export default function ProjectDetailPage({
 		setRatingStep("idle");
 		setSubmitting(false);
 	};
+
+	const toggleHelpful = async (ratingId: number) => {
+		if (!token) return;
+		const res = await fetch("/api/rating-votes", {
+			method: "POST",
+			headers: {
+				"Content-Type": "application/json",
+				Authorization: `Bearer ${token}`,
+			},
+			body: JSON.stringify({ rating_id: ratingId }),
+		});
+		if (!res.ok) return;
+		const data = await res.json();
+		setUserVotes((prev) => ({ ...prev, [ratingId]: data.voted }));
+		setRatings((prev) =>
+			prev.map((r) =>
+				r.id === ratingId ? { ...r, helpful_count: data.helpful_count } : r,
+			),
+		);
+	};
+
+	const sortedRatings = [...ratings].sort((a, b) => {
+		if (ratingSort === "helpful") {
+			const aHelp = a.helpful_count ?? 0;
+			const bHelp = b.helpful_count ?? 0;
+			if (bHelp !== aHelp) return bHelp - aHelp;
+			return new Date(b.created_at).getTime() - new Date(a.created_at).getTime();
+		}
+		return new Date(b.created_at).getTime() - new Date(a.created_at).getTime();
+	});
 
 	if (loading) {
 		return (
@@ -743,7 +791,32 @@ export default function ProjectDetailPage({
 						{/* Existing ratings */}
 						{ratings.length > 0 ? (
 							<div className="space-y-4">
-								{ratings.map((rating) => (
+								<div className="flex items-center justify-between">
+									<p className="text-sm text-ash">{ratings.length} rating{ratings.length !== 1 ? "s" : ""}</p>
+									<div className="flex items-center gap-2">
+										<button
+											onClick={() => setRatingSort("recent")}
+											className={`text-xs px-3 py-1.5 rounded-lg transition-all ${
+												ratingSort === "recent"
+													? "bg-nova/20 text-nova-bright border border-nova/30"
+													: "text-ash hover:text-moonlight border border-transparent"
+											}`}
+										>
+											Most Recent
+										</button>
+										<button
+											onClick={() => setRatingSort("helpful")}
+											className={`text-xs px-3 py-1.5 rounded-lg transition-all ${
+												ratingSort === "helpful"
+													? "bg-nova/20 text-nova-bright border border-nova/30"
+													: "text-ash hover:text-moonlight border border-transparent"
+											}`}
+										>
+											Most Helpful
+										</button>
+									</div>
+								</div>
+								{sortedRatings.map((rating) => (
 									<div
 										key={rating.id}
 										className="glass rounded-2xl p-6"
@@ -808,6 +881,20 @@ export default function ProjectDetailPage({
 													On-chain
 												</a>
 											)}
+											<button
+												onClick={() => toggleHelpful(rating.id)}
+												disabled={!token}
+												className={`ml-auto inline-flex items-center gap-1.5 px-2.5 py-1 rounded-lg text-xs font-medium transition-all ${
+													userVotes[rating.id]
+														? "bg-solar/15 text-solar-bright border border-solar/20"
+														: "text-ash hover:text-moonlight hover:bg-stardust/30 border border-transparent"
+												} ${!token ? "opacity-50 cursor-not-allowed" : "cursor-pointer"}`}
+											>
+												<svg width="12" height="12" viewBox="0 0 24 24" fill={userVotes[rating.id] ? "currentColor" : "none"} stroke="currentColor" strokeWidth="2">
+													<path d="M14 9V5a3 3 0 0 0-3-3l-4 9v11h11.28a2 2 0 0 0 2-1.7l1.38-9a2 2 0 0 0-2-2.3H14zM7 22H4a2 2 0 0 1-2-2v-7a2 2 0 0 1 2-2h3" />
+												</svg>
+												Helpful{rating.helpful_count ? ` (${rating.helpful_count})` : ""}
+											</button>
 										</div>
 									</div>
 								))}

--- a/web/src/lib/db.ts
+++ b/web/src/lib/db.ts
@@ -21,6 +21,11 @@ export const ratingsCol = {
 		return col("ratings");
 	},
 };
+export const ratingVotesCol = {
+	get ref() {
+		return col("rating_votes");
+	},
+};
 export const financialSnapshotsCol = {
 	get ref() {
 		return col("financial_snapshots");

--- a/web/src/lib/firebase.ts
+++ b/web/src/lib/firebase.ts
@@ -7,6 +7,7 @@ const TABLE_BY_COLLECTION: Record<string, string> = {
 	users: "users",
 	projects: "projects",
 	ratings: "ratings",
+	rating_votes: "rating_votes",
 	financial_snapshots: "financial_snapshots",
 	auth_challenges: "auth_challenges",
 	counters: "counters",
@@ -21,7 +22,8 @@ function keyField(collection: string): string {
 	if (
 		collection === "users" ||
 		collection === "projects" ||
-		collection === "ratings"
+		collection === "ratings" ||
+		collection === "rating_votes"
 	) {
 		return "numericId";
 	}
@@ -34,7 +36,8 @@ function normalizeDocId(collection: string, id: string): string | number {
 	if (
 		collection === "users" ||
 		collection === "projects" ||
-		collection === "ratings"
+		collection === "ratings" ||
+		collection === "rating_votes"
 	) {
 		const numeric = Number(id);
 		return Number.isNaN(numeric) ? id : numeric;


### PR DESCRIPTION
closes #213 

- Add rating_votes table (one vote per user per rating)
- POST /api/rating-votes to toggle a helpful vote
- GET /api/rating-votes?rating_ids=... to fetch user's votes
- Include helpful_count in project detail API response
- Add Helpful button with count to each rating on project page
- Add sort toggle (Most Recent / Most Helpful) for ratings list