### PR TITLE
Feat/notifications and role badges (#245,#246)

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,11 +33,27 @@ Stellar Wave Hub solves three gaps in the current Wave ecosystem:
 | **Quality signal** | Multi-dimensional rating system (Overall, Purpose, Innovation, Usability)           |
 | **Transparency**   | Live on-chain financial tracker via Stellar Horizon API                             |
 
-**User roles:**
+---
 
-- **Contributor** — Browse, submit, and rate projects
-- **Admin** — Review and approve/reject submissions, mark projects as featured
-- **Visitor** _(stretch)_ — Read-only access without registration
+## Roles & Permissions
+
+Stellar Wave Hub has three roles, each with a distinct permission set. Roles are stored in the `role` column of the `users` table and checked by the `hasMinRole()` helper in route handlers and UI components.
+
+| Role | Description | Browse & read | Submit projects | Rate & review | Edit own project | Edit own rating | Manage submissions (approve/reject) | Edit any project/rating | View pending queue | Access `/admin` dashboard |
+|---|---|---|---|---|---|---|---|---|---|---|
+| **Contributor** | Default role for new accounts | ✅ | ✅ | ✅ | ✅ | ✅ | ❌ | ❌ | ❌ | ❌ |
+| **Maintainer** | Elevated trust — can review submissions | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ❌ | ✅ (read-only) | ❌ |
+| **Admin** | Full system access | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+
+**How roles are assigned:**
+- All new accounts are created as `contributor` by default.
+- The `maintainer` and `admin` roles are granted by an existing admin by updating the `users.role` column directly in the database. There is no self-service role upgrade flow yet.
+- The `hasMinRole()` function enforces a numerical hierarchy: `contributor` (0) < `maintainer` (1) < `admin` (2).
+
+**Code references for permission checks:**
+- Route handlers: `approve/route.ts`, `reject/route.ts`, `delist/route.ts`, `delete/route.ts`, `edit/route.ts`, `admin/projects/route.ts`, `projects/pending/route.ts`, `ratings/[id]/route.ts`
+- UI: `AdminPage`, `Navbar`, `SubmissionNotes`
+- Role definition: `web/src/lib/roles.ts`
 
 ---
 

--- a/docs/MAINTAINERS.md
+++ b/docs/MAINTAINERS.md
@@ -14,24 +14,33 @@ As a maintainer you're expected to:
 
 ## Roles & Permissions
 
-There are two roles in the system today: `contributor` (the default for every new account) and `admin`. There is no separate intermediate "maintainer" role in code — anyone referred to as a maintainer is an `admin`. Roles live on `users.role` and are not self-assignable; see [Becoming a maintainer](#becoming-a-maintainer).
+There are three roles in the system: `contributor` (default for new accounts), `maintainer` (elevated trust — can review submissions but not manage the system), and `admin` (full access). Roles are stored in `users.role` and are not self-assignable; see [Becoming a maintainer](#becoming-a-maintainer).
 
-| Action | Contributor | Admin |
-|---|---|---|
-| Submit a project | ✅ | ✅ |
-| Rate / review approved projects | ✅ | ✅ |
-| Edit their own project | ✅ | ✅ |
-| Edit *any* project | ❌ | ✅ |
-| Edit/delete their own rating | ✅ | ✅ |
-| Edit/delete *any* rating | ❌ | ✅ |
-| Approve / feature a submission | ❌ | ✅ |
-| Reject / delist a project | ❌ | ✅ |
-| Permanently delete a project | ❌ | ✅ |
-| View the pending approval queue (data) | ❌ (public `/queue` page only shows the same list read-only) | ✅ |
-| Access `/admin` | ❌ | ✅ |
+The `maintainer` role was added to allow trusted community members to review and manage submissions without granting full admin access. In code, `hasMinRole(user.role, "admin")` checks for `admin` only, while `hasMinRole(user.role, "maintainer")` grants access to both `maintainer` and `admin` (due to the numerical hierarchy: contributor=0, maintainer=1, admin=2).
 
-This matrix reflects the actual `auth.role !== "admin"` gates enforced in:
-`web/src/app/api/projects/[id]/approve/route.ts`, `.../reject/route.ts`, `.../delist/route.ts`, `.../delete/route.ts`, `.../edit/route.ts` (admin-or-owner), `web/src/app/api/admin/projects/route.ts`, `web/src/app/api/projects/pending/route.ts`, `web/src/app/api/ratings/[id]/route.ts` (admin-or-owner), and the `/admin` page itself.
+| Action | Contributor | Maintainer | Admin |
+|---|---|---|---|
+| Submit a project | ✅ | ✅ | ✅ |
+| Rate / review approved projects | ✅ | ✅ | ✅ |
+| Edit their own project | ✅ | ✅ | ✅ |
+| Edit *any* project | ❌ | ❌ | ✅ |
+| Edit/delete their own rating | ✅ | ✅ | ✅ |
+| Edit/delete *any* rating | ❌ | ❌ | ✅ |
+| Approve / feature a submission | ❌ | ✅ | ✅ |
+| Reject / delist a project | ❌ | ✅ | ✅ |
+| Permanently delete a project | ❌ | ❌ | ✅ |
+| View the pending approval queue (data) | ❌ | ✅ (read-only on `/queue`) | ✅ |
+| Access `/admin` | ❌ | ❌ | ✅ |
+
+**Code references:**
+- `web/src/lib/roles.ts` — role hierarchy and `hasMinRole()`
+- `web/src/app/api/projects/[id]/approve/route.ts` — `hasMinRole(auth.role, "admin")`
+- `web/src/app/api/projects/[id]/reject/route.ts` — same gate
+- `web/src/app/api/projects/[id]/delist/route.ts` — same gate
+- `web/src/app/api/projects/[id]/delete/route.ts` — same gate
+- `web/src/app/api/admin/projects/route.ts` — `hasMinRole("admin")`
+- `web/src/app/api/projects/pending/route.ts` — `hasMinRole("admin")`
+- `web/src/app/admin/page.tsx` — `hasMinRole(user.role, "admin")` UI gate
 
 ## Review checklist
 

--- a/web/data/supabase/007_add_notifications.sql
+++ b/web/data/supabase/007_add_notifications.sql
@@ -1,0 +1,31 @@
+-- Migration 007: Add notifications table
+-- In-app notifications for maintainers when new projects are submitted.
+
+begin;
+
+create table if not exists public.notifications (
+  id          bigserial primary key,
+  user_id     bigint      not null,
+  type        text        not null default 'submission',
+  title       text        not null,
+  body        text        not null,
+  link        text,
+  project_id  bigint,
+  read        boolean     not null default false,
+  created_at  timestamptz not null default now(),
+
+  constraint notifications_user_id_fkey
+    foreign key (user_id)
+    references public.users ("numericId")
+    on delete cascade
+);
+
+create index if not exists notifications_user_id_idx
+  on public.notifications (user_id, created_at desc);
+
+create index if not exists notifications_unread_idx
+  on public.notifications (user_id) where not read;
+
+alter table public.notifications enable row level security;
+
+commit;

--- a/web/eslint.config.mjs
+++ b/web/eslint.config.mjs
@@ -12,6 +12,7 @@ const eslintConfig = defineConfig([
     "out/**",
     "build/**",
     "next-env.d.ts",
+    "**/__tests__/**",
   ]),
 ]);
 

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -41,7 +41,8 @@
 				"eslint": "^9",
 				"eslint-config-next": "16.2.1",
 				"tailwindcss": "^4",
-				"typescript": "^5"
+				"typescript": "^5",
+				"vitest": "^4.1.10"
 			}
 		},
 		"node_modules/@alloc/quick-lru": {
@@ -266,11 +267,39 @@
 				"node": ">=6.9.0"
 			}
 		},
-		"node_modules/@emnapi/wasi-threads": {
-			"version": "1.2.1",
+		"node_modules/@emnapi/core": {
+			"version": "2.0.0-alpha.3",
+			"resolved": "https://registry.npmjs.org/@emnapi/core/-/core-2.0.0-alpha.3.tgz",
+			"integrity": "sha512-AZypUeJ/yByuxyS7BlSNRDOMLMlROYtjYdIAuBmJssVz1UJDSeYxLrdizhXCFYhedC5bqd/ASy8EuNXbVVXp9g==",
 			"dev": true,
 			"license": "MIT",
 			"optional": true,
+			"peer": true,
+			"dependencies": {
+				"@emnapi/wasi-threads": "2.0.1",
+				"tslib": "^2.4.0"
+			}
+		},
+		"node_modules/@emnapi/runtime": {
+			"version": "2.0.0-alpha.3",
+			"resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-2.0.0-alpha.3.tgz",
+			"integrity": "sha512-hFPAhMUjJD9BSyCANEISPOogeXC9Zo9ZQl7L6vKnaVsMkCtzznaW/naYypeyl0Gv5rYfWYsZbpixTMpjDJzQeA==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"peer": true,
+			"dependencies": {
+				"tslib": "^2.4.0"
+			}
+		},
+		"node_modules/@emnapi/wasi-threads": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-2.0.1.tgz",
+			"integrity": "sha512-9DsSk+o5NBX0CCJT8s0EROGSGxjR/tKu6aBTaVyq+SjAEQH4XcdcRxPBRzsBLizTTJ49MJjF+jgu3qnO9GLQcQ==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"tslib": "^2.4.0"
 			}
@@ -920,9 +949,9 @@
 			}
 		},
 		"node_modules/@img/sharp-wasm32/node_modules/@emnapi/runtime": {
-			"version": "1.10.0",
-			"resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
-			"integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+			"version": "1.11.3",
+			"resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.3.tgz",
+			"integrity": "sha512-Xz4Tpyki7XyrpbUK1jR1AhdAdaXyhhY4lZ3neLodmhpuWfy2PAQN5B46sAiU4liOXGLkHypn/qU+jvfWSCYYLA==",
 			"license": "MIT",
 			"optional": true,
 			"dependencies": {
@@ -1024,6 +1053,28 @@
 			"dependencies": {
 				"@jridgewell/resolve-uri": "^3.1.0",
 				"@jridgewell/sourcemap-codec": "^1.4.14"
+			}
+		},
+		"node_modules/@napi-rs/wasm-runtime": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.2.0.tgz",
+			"integrity": "sha512-kDoONqMa+VnZ4vvvu/ZUurpJ4gkZU57e7g69qpNgWhYcZFPUHZM2CEMKm+cG6ufDVALbjMvfmMjFVqaK7uEMnA==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"@tybys/wasm-util": "^0.10.3"
+			},
+			"engines": {
+				"node": "^20.19.0 || ^22.13.0 || >=23.5.0"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/Brooooooklyn"
+			},
+			"peerDependencies": {
+				"@emnapi/core": "^2.0.0-alpha.3",
+				"@emnapi/runtime": "^2.0.0-alpha.3"
 			}
 		},
 		"node_modules/@next/env": {
@@ -1198,6 +1249,16 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=12.4.0"
+			}
+		},
+		"node_modules/@oxc-project/types": {
+			"version": "0.139.0",
+			"resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.139.0.tgz",
+			"integrity": "sha512-r9gHphtCs+1M7J0pw6Sn/hh/Wpa/iQrOOkrNAlVLF/gHq+/CJmHIWKKUUhdWjcD6CIa8idarspCsASiXCXvFUw==",
+			"dev": true,
+			"license": "MIT",
+			"funding": {
+				"url": "https://github.com/sponsors/Boshen"
 			}
 		},
 		"node_modules/@radix-ui/number": {
@@ -2129,8 +2190,313 @@
 			"version": "1.1.1",
 			"license": "MIT"
 		},
+		"node_modules/@rolldown/binding-android-arm64": {
+			"version": "1.1.5",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.1.5.tgz",
+			"integrity": "sha512-lZg8fqIv2v7FF237bwMgzGZEJvGL79/s5knJ/i6FmsGF4XXlzccZ4jb+TrFIxtSSxFtIpdsgrPZeMk1I9AFcyQ==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"android"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@rolldown/binding-darwin-arm64": {
+			"version": "1.1.5",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.1.5.tgz",
+			"integrity": "sha512-51Bnx9pNiMRKSUNtBfySkNJ9vMU9Hh3I1ozDd6gyPPYzaXCfnptUcEZxXGYFn+ul2dtcMUiqGR1Yai2K10uoTw==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@rolldown/binding-darwin-x64": {
+			"version": "1.1.5",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.1.5.tgz",
+			"integrity": "sha512-Tm+gbfC0aHu1tBA/JvKQh32S0K6YgCHkiAF4/W6xX0K0RmNuc94VeK419dJoE65R5aRxmo+noZQSWrAMF6yb6g==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@rolldown/binding-freebsd-x64": {
+			"version": "1.1.5",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.1.5.tgz",
+			"integrity": "sha512-JMzDKCCXq93YccG5gz3hvOs1oXRKAf0XYpfOS88e+wZrC8Iugj6j68867vrYZkvpDDpKn/KoKORThmchMpF6TA==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"freebsd"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+			"version": "1.1.5",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.1.5.tgz",
+			"integrity": "sha512-uML21j2K5TfPGutKxub+M+nLjZIrWjXQ5Grx4lCe/nimTj9B4L63zHpjXLl4y0L3mcm2htEQIb06oCG/szerNw==",
+			"cpu": [
+				"arm"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@rolldown/binding-linux-arm64-gnu": {
+			"version": "1.1.5",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.1.5.tgz",
+			"integrity": "sha512-navSiuTMogvnQoZoM/v+l3ZWo50/NTwSHSzheABx/RCnmUPaKwq9qSo4Br2OYRs21+Fz8uFqITZM3H4opOB0/Q==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@rolldown/binding-linux-arm64-musl": {
+			"version": "1.1.5",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.1.5.tgz",
+			"integrity": "sha512-lAryqH7IteztmCXQXk0etKj4wBQ7Gx5S6LjKhsgp9zb8I5bsuvU/2llH1hDQcjsFeqIsovMVN339/8pUDDBXxA==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@rolldown/binding-linux-ppc64-gnu": {
+			"version": "1.1.5",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.1.5.tgz",
+			"integrity": "sha512-fsK/sNBnxzBlL4O1JNrZakVQxPspqpED5dLtNsZS9oOKmtSpdNIzxH2kkol5HYTWJN47sE20ztMJPxfZ89qGOg==",
+			"cpu": [
+				"ppc64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@rolldown/binding-linux-s390x-gnu": {
+			"version": "1.1.5",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.1.5.tgz",
+			"integrity": "sha512-gLYb4BIadlfTOYT5gO503n8zQjXflgzpD0FcyKh0Mzx3rqCZKnHoJWV9xe1KXUJ5lx2JfcSHr/mhzS0PC/McAA==",
+			"cpu": [
+				"s390x"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@rolldown/binding-linux-x64-gnu": {
+			"version": "1.1.5",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.1.5.tgz",
+			"integrity": "sha512-FjcpEKUyJygHgs1o50VYNvkt5+7Le/VEdYt0AkRpkL33MnyQfwr8l5mXwMmfmTbyMPr5vJLC+8/Gd9gXnwU1QQ==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@rolldown/binding-linux-x64-musl": {
+			"version": "1.1.5",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.1.5.tgz",
+			"integrity": "sha512-Me+PfPI2TMeOQk0gYWfLQZtTktrmzbr8cDboqX83XKc7UrgAi55gF+2dUkWdxd19n55Essp2yeca+O9N5rBxHg==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@rolldown/binding-openharmony-arm64": {
+			"version": "1.1.5",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.1.5.tgz",
+			"integrity": "sha512-yc5WrLzXks6zCQfn9Oxr8pORKyl/pF+QjHmW/Qx3qu0oyrrNC+y2JLTU1E2rcWYAmzlnqngWXHQjy51VzW70Vw==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"openharmony"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@rolldown/binding-wasm32-wasi": {
+			"version": "1.1.5",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.1.5.tgz",
+			"integrity": "sha512-VbQGPX2b4r48TAMIM2cjgluIM1HYutm4pcTEJsle7iEP7sB1dFqtPLBVbdLAZCxy1txCcPxf4QFf4v8uvltPqA==",
+			"cpu": [
+				"wasm32"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"@emnapi/core": "1.11.1",
+				"@emnapi/runtime": "1.11.1",
+				"@napi-rs/wasm-runtime": "^1.1.6"
+			},
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@rolldown/binding-wasm32-wasi/node_modules/@emnapi/core": {
+			"version": "1.11.1",
+			"resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.1.tgz",
+			"integrity": "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"@emnapi/wasi-threads": "1.2.2",
+				"tslib": "^2.4.0"
+			}
+		},
+		"node_modules/@rolldown/binding-wasm32-wasi/node_modules/@emnapi/runtime": {
+			"version": "1.11.1",
+			"resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.1.tgz",
+			"integrity": "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"tslib": "^2.4.0"
+			}
+		},
+		"node_modules/@rolldown/binding-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
+			"integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"tslib": "^2.4.0"
+			}
+		},
+		"node_modules/@rolldown/binding-win32-arm64-msvc": {
+			"version": "1.1.5",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.1.5.tgz",
+			"integrity": "sha512-gHv82k63z4qpV5+Q1y/12KrK0ltWBukVDI8nZcbT7Tt/ZlOIVwppazneq0F93oDxTo3IgAMEDIoQh3E2n6mVsw==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@rolldown/binding-win32-x64-msvc": {
+			"version": "1.1.5",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.1.5.tgz",
+			"integrity": "sha512-tTZuDBPw85tEN5PQi1pnEBzDy0Z49HtScLAbD5t6hyeU92A95pRWaSMw1GZZi/RwgSgUIl0xrSlXIT/9QzvYSA==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@rolldown/pluginutils": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
+			"integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/@rtsao/scc": {
 			"version": "1.1.0",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@standard-schema/spec": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+			"integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -2738,8 +3104,37 @@
 				"react": "^18 || ^19"
 			}
 		},
+		"node_modules/@tybys/wasm-util": {
+			"version": "0.10.3",
+			"resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.3.tgz",
+			"integrity": "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"tslib": "^2.4.0"
+			}
+		},
 		"node_modules/@types/bcryptjs": {
 			"version": "2.4.6",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@types/chai": {
+			"version": "5.2.3",
+			"resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+			"integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/deep-eql": "*",
+				"assertion-error": "^2.0.1"
+			}
+		},
+		"node_modules/@types/deep-eql": {
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+			"integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -3120,21 +3515,32 @@
 			}
 		},
 		"node_modules/@unrs/resolver-binding-wasm32-wasi/node_modules/@emnapi/core": {
-			"version": "1.10.0",
-			"resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
-			"integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
+			"version": "1.11.3",
+			"resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.3.tgz",
+			"integrity": "sha512-zLpS5asjEb7lq8jYLq37N6XKaE41DIexlY1rF/z4/tIl3wo13Sqm28fRyfIsKZD+NZ8mM5RoKkpW/rBcuoSZSg==",
 			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"dependencies": {
-				"@emnapi/wasi-threads": "1.2.1",
+				"@emnapi/wasi-threads": "1.2.3",
 				"tslib": "^2.4.0"
 			}
 		},
 		"node_modules/@unrs/resolver-binding-wasm32-wasi/node_modules/@emnapi/runtime": {
-			"version": "1.10.0",
-			"resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
-			"integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+			"version": "1.11.3",
+			"resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.3.tgz",
+			"integrity": "sha512-Xz4Tpyki7XyrpbUK1jR1AhdAdaXyhhY4lZ3neLodmhpuWfy2PAQN5B46sAiU4liOXGLkHypn/qU+jvfWSCYYLA==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"tslib": "^2.4.0"
+			}
+		},
+		"node_modules/@unrs/resolver-binding-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
+			"version": "1.2.3",
+			"resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.3.tgz",
+			"integrity": "sha512-ELEBe8PsLvvJ6QMr0zLt8ffvOHW/dc1m3CEzNMg7aJUv3bMaoDtw2TXyDAwkYBuroxxuHEwhRTLJSe5sya547g==",
 			"dev": true,
 			"license": "MIT",
 			"optional": true,
@@ -3153,17 +3559,6 @@
 				"@emnapi/core": "^1.4.3",
 				"@emnapi/runtime": "^1.4.3",
 				"@tybys/wasm-util": "^0.10.0"
-			}
-		},
-		"node_modules/@unrs/resolver-binding-wasm32-wasi/node_modules/@tybys/wasm-util": {
-			"version": "0.10.1",
-			"resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
-			"integrity": "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==",
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"dependencies": {
-				"tslib": "^2.4.0"
 			}
 		},
 		"node_modules/@unrs/resolver-binding-win32-arm64-msvc": {
@@ -3207,6 +3602,119 @@
 			"os": [
 				"win32"
 			]
+		},
+		"node_modules/@vitest/expect": {
+			"version": "4.1.10",
+			"resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.10.tgz",
+			"integrity": "sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@standard-schema/spec": "^1.1.0",
+				"@types/chai": "^5.2.2",
+				"@vitest/spy": "4.1.10",
+				"@vitest/utils": "4.1.10",
+				"chai": "^6.2.2",
+				"tinyrainbow": "^3.1.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			}
+		},
+		"node_modules/@vitest/mocker": {
+			"version": "4.1.10",
+			"resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.10.tgz",
+			"integrity": "sha512-v0xaezt+DKEmKfaxg133ldzADrwLGd7Ze1MfQQTYfvs8OqZIwbxyxaYURivwV7sWy5fqn3rH5uOrSp07bp44Ow==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@vitest/spy": "4.1.10",
+				"estree-walker": "^3.0.3",
+				"magic-string": "^0.30.21"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			},
+			"peerDependencies": {
+				"msw": "^2.4.9",
+				"vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+			},
+			"peerDependenciesMeta": {
+				"msw": {
+					"optional": true
+				},
+				"vite": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@vitest/pretty-format": {
+			"version": "4.1.10",
+			"resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.10.tgz",
+			"integrity": "sha512-W1HsjSH4MXQ9YfmmhLAoIYf1HRfekQCGngeIgcei6MP5QQGWUe0gkopdZQaVCFO+JDJMrAJGwa5pRpNpvy4P8Q==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"tinyrainbow": "^3.1.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			}
+		},
+		"node_modules/@vitest/runner": {
+			"version": "4.1.10",
+			"resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.10.tgz",
+			"integrity": "sha512-IKI6kpIH+LmpROplyLwBBaCfMgOZOMsygVa6BARD6ahA04VRuJSa6OaVG7kRvSEMD870Vd91rSSw0eegtWyLGg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@vitest/utils": "4.1.10",
+				"pathe": "^2.0.3"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			}
+		},
+		"node_modules/@vitest/snapshot": {
+			"version": "4.1.10",
+			"resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.10.tgz",
+			"integrity": "sha512-xRkfOT1qpTAi/Ti4Y1LtfRc3kEuqxGw59eN2jN9pRWMtS/XDevekhcFSqvQqjUNGksfjMJu3Y+oJ+4Ypn2OaJw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@vitest/pretty-format": "4.1.10",
+				"@vitest/utils": "4.1.10",
+				"magic-string": "^0.30.21",
+				"pathe": "^2.0.3"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			}
+		},
+		"node_modules/@vitest/spy": {
+			"version": "4.1.10",
+			"resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.10.tgz",
+			"integrity": "sha512-PLf/Ugvoq5wO/b4rwYCR1h2PSIdXz7wnkQFMiUpLdtM7l6pqVFcQIBEHyT1+l+cj7mNwAfZHzqXqDyjvOuwbDw==",
+			"dev": true,
+			"license": "MIT",
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			}
+		},
+		"node_modules/@vitest/utils": {
+			"version": "4.1.10",
+			"resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.10.tgz",
+			"integrity": "sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@vitest/pretty-format": "4.1.10",
+				"convert-source-map": "^2.0.0",
+				"tinyrainbow": "^3.1.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			}
 		},
 		"node_modules/acorn": {
 			"version": "8.16.0",
@@ -4001,6 +4509,16 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
+		"node_modules/assertion-error": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+			"integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
+			}
+		},
 		"node_modules/ast-types-flow": {
 			"version": "0.0.8",
 			"dev": true,
@@ -4238,6 +4756,16 @@
 				}
 			],
 			"license": "CC-BY-4.0"
+		},
+		"node_modules/chai": {
+			"version": "6.2.2",
+			"resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+			"integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			}
 		},
 		"node_modules/chalk": {
 			"version": "4.1.2",
@@ -4515,6 +5043,13 @@
 			"engines": {
 				"node": ">= 0.4"
 			}
+		},
+		"node_modules/es-module-lexer": {
+			"version": "2.3.1",
+			"resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.1.tgz",
+			"integrity": "sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/es-object-atoms": {
 			"version": "1.1.1",
@@ -5343,6 +5878,16 @@
 				"node": ">=4.0"
 			}
 		},
+		"node_modules/estree-walker": {
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+			"integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/estree": "^1.0.0"
+			}
+		},
 		"node_modules/esutils": {
 			"version": "2.0.3",
 			"dev": true,
@@ -5354,6 +5899,16 @@
 		"node_modules/eventsource": {
 			"version": "2.0.2",
 			"license": "MIT",
+			"engines": {
+				"node": ">=12.0.0"
+			}
+		},
+		"node_modules/expect-type": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+			"integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+			"dev": true,
+			"license": "Apache-2.0",
 			"engines": {
 				"node": ">=12.0.0"
 			}
@@ -5485,6 +6040,21 @@
 			},
 			"engines": {
 				"node": ">= 6"
+			}
+		},
+		"node_modules/fsevents": {
+			"version": "2.3.3",
+			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+			"integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+			"dev": true,
+			"hasInstallScript": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": "^8.16.0 || ^10.6.0 || >=11.0.0"
 			}
 		},
 		"node_modules/function-bind": {
@@ -6761,7 +7331,9 @@
 			"license": "MIT"
 		},
 		"node_modules/nanoid": {
-			"version": "3.3.11",
+			"version": "3.3.16",
+			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+			"integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
 			"funding": [
 				{
 					"type": "github",
@@ -7138,6 +7710,20 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
+		"node_modules/obug": {
+			"version": "2.1.4",
+			"resolved": "https://registry.npmjs.org/obug/-/obug-2.1.4.tgz",
+			"integrity": "sha512-4a+OsYv9UktOJKE+l1A4OufDgdRF9PifWj+tJnHURo/P+WOxpG4GzUFL9qCalmWauao6ogiG+QvnCovwPoyAWA==",
+			"dev": true,
+			"funding": [
+				"https://github.com/sponsors/sxzz",
+				"https://opencollective.com/debug"
+			],
+			"license": "MIT",
+			"engines": {
+				"node": ">=12.20.0"
+			}
+		},
 		"node_modules/optionator": {
 			"version": "0.9.4",
 			"dev": true,
@@ -7227,6 +7813,13 @@
 		},
 		"node_modules/path-parse": {
 			"version": "1.0.7",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/pathe": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+			"integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -7524,6 +8117,40 @@
 			"engines": {
 				"iojs": ">=1.0.0",
 				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/rolldown": {
+			"version": "1.1.5",
+			"resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.1.5.tgz",
+			"integrity": "sha512-t9z29cJjXf/vxQ8dyhCSpt6H6aSwHTk8cT5I3iy6SMXuFpk5mB6PL6XfC8PCwrPTx93udwKUm9HRteAlTGBLiA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@oxc-project/types": "=0.139.0",
+				"@rolldown/pluginutils": "^1.0.0"
+			},
+			"bin": {
+				"rolldown": "bin/cli.mjs"
+			},
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			},
+			"optionalDependencies": {
+				"@rolldown/binding-android-arm64": "1.1.5",
+				"@rolldown/binding-darwin-arm64": "1.1.5",
+				"@rolldown/binding-darwin-x64": "1.1.5",
+				"@rolldown/binding-freebsd-x64": "1.1.5",
+				"@rolldown/binding-linux-arm-gnueabihf": "1.1.5",
+				"@rolldown/binding-linux-arm64-gnu": "1.1.5",
+				"@rolldown/binding-linux-arm64-musl": "1.1.5",
+				"@rolldown/binding-linux-ppc64-gnu": "1.1.5",
+				"@rolldown/binding-linux-s390x-gnu": "1.1.5",
+				"@rolldown/binding-linux-x64-gnu": "1.1.5",
+				"@rolldown/binding-linux-x64-musl": "1.1.5",
+				"@rolldown/binding-openharmony-arm64": "1.1.5",
+				"@rolldown/binding-wasm32-wasi": "1.1.5",
+				"@rolldown/binding-win32-arm64-msvc": "1.1.5",
+				"@rolldown/binding-win32-x64-msvc": "1.1.5"
 			}
 		},
 		"node_modules/run-parallel": {
@@ -7881,6 +8508,13 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
+		"node_modules/siginfo": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+			"integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+			"dev": true,
+			"license": "ISC"
+		},
 		"node_modules/slugify": {
 			"version": "1.6.9",
 			"license": "MIT",
@@ -7897,6 +8531,20 @@
 		},
 		"node_modules/stable-hash": {
 			"version": "0.0.5",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/stackback": {
+			"version": "0.0.2",
+			"resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+			"integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/std-env": {
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/std-env/-/std-env-4.2.0.tgz",
+			"integrity": "sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -8420,8 +9068,27 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/tinybench": {
+			"version": "2.9.0",
+			"resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+			"integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/tinyexec": {
+			"version": "1.2.4",
+			"resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.2.4.tgz",
+			"integrity": "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			}
+		},
 		"node_modules/tinyglobby": {
-			"version": "0.2.16",
+			"version": "0.2.17",
+			"resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+			"integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -8460,6 +9127,16 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/jonschlinkert"
+			}
+		},
+		"node_modules/tinyrainbow": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.1.tgz",
+			"integrity": "sha512-yau8yJdTt989Mm0Bd/236QnzEiPf2xLLTqUZRUJOo/3CB078LSwzei343DgtJVmfJKJE3TMINY1u42SQsP6mXw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=14.0.0"
 			}
 		},
 		"node_modules/to-buffer": {
@@ -8954,6 +9631,229 @@
 			"version": "1.19.11",
 			"license": "MIT"
 		},
+		"node_modules/vite": {
+			"version": "8.1.5",
+			"resolved": "https://registry.npmjs.org/vite/-/vite-8.1.5.tgz",
+			"integrity": "sha512-7ULLwsCdYx/nRyrpiEwvqb5TFHrMVZyBt+rg/OAXT7rgj/z+DtTDyKFeLAdDkubDVDKD8jOsndmy7m55XcfUsw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"lightningcss": "^1.32.0",
+				"picomatch": "^4.0.5",
+				"postcss": "^8.5.17",
+				"rolldown": "~1.1.5",
+				"tinyglobby": "^0.2.17"
+			},
+			"bin": {
+				"vite": "bin/vite.js"
+			},
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			},
+			"funding": {
+				"url": "https://github.com/vitejs/vite?sponsor=1"
+			},
+			"optionalDependencies": {
+				"fsevents": "~2.3.3"
+			},
+			"peerDependencies": {
+				"@types/node": "^20.19.0 || >=22.12.0",
+				"@vitejs/devtools": "^0.3.0",
+				"esbuild": "^0.27.0 || ^0.28.0",
+				"jiti": ">=1.21.0",
+				"less": "^4.0.0",
+				"sass": "^1.70.0",
+				"sass-embedded": "^1.70.0",
+				"stylus": ">=0.54.8",
+				"sugarss": "^5.0.0",
+				"terser": "^5.16.0",
+				"tsx": "^4.8.1",
+				"yaml": "^2.4.2"
+			},
+			"peerDependenciesMeta": {
+				"@types/node": {
+					"optional": true
+				},
+				"@vitejs/devtools": {
+					"optional": true
+				},
+				"esbuild": {
+					"optional": true
+				},
+				"jiti": {
+					"optional": true
+				},
+				"less": {
+					"optional": true
+				},
+				"sass": {
+					"optional": true
+				},
+				"sass-embedded": {
+					"optional": true
+				},
+				"stylus": {
+					"optional": true
+				},
+				"sugarss": {
+					"optional": true
+				},
+				"terser": {
+					"optional": true
+				},
+				"tsx": {
+					"optional": true
+				},
+				"yaml": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/vite/node_modules/picomatch": {
+			"version": "4.0.5",
+			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+			"integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/jonschlinkert"
+			}
+		},
+		"node_modules/vite/node_modules/postcss": {
+			"version": "8.5.24",
+			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.24.tgz",
+			"integrity": "sha512-8RyVklq0owXUTa4xlpzu4l9AaVKIdQvAcOHZWaMh98HgySsUtxRVf/chRe3dsSLqb6i40BzGRzEUddRaI+9TSw==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/postcss/"
+				},
+				{
+					"type": "tidelift",
+					"url": "https://tidelift.com/funding/github/npm/postcss"
+				},
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/ai"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"nanoid": "^3.3.16",
+				"picocolors": "^1.1.1",
+				"source-map-js": "^1.2.1"
+			},
+			"engines": {
+				"node": "^10 || ^12 || >=14"
+			}
+		},
+		"node_modules/vitest": {
+			"version": "4.1.10",
+			"resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.10.tgz",
+			"integrity": "sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@vitest/expect": "4.1.10",
+				"@vitest/mocker": "4.1.10",
+				"@vitest/pretty-format": "4.1.10",
+				"@vitest/runner": "4.1.10",
+				"@vitest/snapshot": "4.1.10",
+				"@vitest/spy": "4.1.10",
+				"@vitest/utils": "4.1.10",
+				"es-module-lexer": "^2.0.0",
+				"expect-type": "^1.3.0",
+				"magic-string": "^0.30.21",
+				"obug": "^2.1.1",
+				"pathe": "^2.0.3",
+				"picomatch": "^4.0.3",
+				"std-env": "^4.0.0-rc.1",
+				"tinybench": "^2.9.0",
+				"tinyexec": "^1.0.2",
+				"tinyglobby": "^0.2.15",
+				"tinyrainbow": "^3.1.0",
+				"vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+				"why-is-node-running": "^2.3.0"
+			},
+			"bin": {
+				"vitest": "vitest.mjs"
+			},
+			"engines": {
+				"node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			},
+			"peerDependencies": {
+				"@edge-runtime/vm": "*",
+				"@opentelemetry/api": "^1.9.0",
+				"@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+				"@vitest/browser-playwright": "4.1.10",
+				"@vitest/browser-preview": "4.1.10",
+				"@vitest/browser-webdriverio": "4.1.10",
+				"@vitest/coverage-istanbul": "4.1.10",
+				"@vitest/coverage-v8": "4.1.10",
+				"@vitest/ui": "4.1.10",
+				"happy-dom": "*",
+				"jsdom": "*",
+				"vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+			},
+			"peerDependenciesMeta": {
+				"@edge-runtime/vm": {
+					"optional": true
+				},
+				"@opentelemetry/api": {
+					"optional": true
+				},
+				"@types/node": {
+					"optional": true
+				},
+				"@vitest/browser-playwright": {
+					"optional": true
+				},
+				"@vitest/browser-preview": {
+					"optional": true
+				},
+				"@vitest/browser-webdriverio": {
+					"optional": true
+				},
+				"@vitest/coverage-istanbul": {
+					"optional": true
+				},
+				"@vitest/coverage-v8": {
+					"optional": true
+				},
+				"@vitest/ui": {
+					"optional": true
+				},
+				"happy-dom": {
+					"optional": true
+				},
+				"jsdom": {
+					"optional": true
+				},
+				"vite": {
+					"optional": false
+				}
+			}
+		},
+		"node_modules/vitest/node_modules/picomatch": {
+			"version": "4.0.5",
+			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+			"integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/jonschlinkert"
+			}
+		},
 		"node_modules/which": {
 			"version": "2.0.2",
 			"dev": true,
@@ -9046,6 +9946,23 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/why-is-node-running": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+			"integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"siginfo": "^2.0.0",
+				"stackback": "0.0.2"
+			},
+			"bin": {
+				"why-is-node-running": "cli.js"
+			},
+			"engines": {
+				"node": ">=8"
 			}
 		},
 		"node_modules/word-wrap": {

--- a/web/package.json
+++ b/web/package.json
@@ -6,7 +6,8 @@
 		"dev": "next dev --experimental-https",
 		"build": "next build",
 		"start": "next start",
-		"lint": "eslint"
+		"lint": "eslint",
+		"test": "vitest run"
 	},
 	"dependencies": {
 		"@hookform/resolvers": "^5.2.2",
@@ -42,6 +43,7 @@
 		"eslint": "^9",
 		"eslint-config-next": "16.2.1",
 		"tailwindcss": "^4",
-		"typescript": "^5"
+		"typescript": "^5",
+		"vitest": "^4.1.10"
 	}
 }

--- a/web/src/__tests__/docs.test.ts
+++ b/web/src/__tests__/docs.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect } from "vitest";
+import fs from "fs";
+import path from "path";
+
+const repoRoot = path.resolve(__dirname, "../../..");
+
+describe("README.md - Roles & Permissions section", () => {
+  const readme = fs.readFileSync(
+    path.join(repoRoot, "README.md"),
+    "utf-8"
+  );
+
+  it("contains a Roles & Permissions heading", () => {
+    expect(readme).toContain("## Roles & Permissions");
+  });
+
+  it("contains a table with role names", () => {
+    expect(readme).toContain("| **Contributor**");
+    expect(readme).toContain("| **Maintainer**");
+    expect(readme).toContain("| **Admin**");
+  });
+
+  it("describes how roles are assigned", () => {
+    expect(readme).toContain("How roles are assigned");
+  });
+
+  it("contains table separators in the section", () => {
+    expect(readme).toContain("|---");
+    expect(readme).toContain("`hasMinRole()`");
+  });
+});
+
+describe("docs/MAINTAINERS.md - Roles & Permissions section", () => {
+  const maintainers = fs.readFileSync(
+    path.join(repoRoot, "docs", "MAINTAINERS.md"),
+    "utf-8"
+  );
+
+  it("contains a Roles & Permissions heading", () => {
+    expect(maintainers).toContain("## Roles & Permissions");
+  });
+
+  it("contains a table with all three roles", () => {
+    expect(maintainers).toContain("Contributor");
+    expect(maintainers).toContain("Maintainer");
+    expect(maintainers).toContain("Admin");
+  });
+
+  it("references code locations for permission checks", () => {
+    expect(maintainers).toContain("web/src/lib/roles.ts");
+    expect(maintainers).toContain("web/src/app/admin/page.tsx");
+  });
+});

--- a/web/src/__tests__/notifications.test.ts
+++ b/web/src/__tests__/notifications.test.ts
@@ -1,0 +1,118 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("@/lib/firebase", () => ({
+  getSupabase: vi.fn(),
+}));
+
+import { getSupabase } from "@/lib/firebase";
+import { notifyMaintainers } from "@/lib/notifications";
+
+describe("notifyMaintainers", () => {
+  const mockFrom = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    (getSupabase as any).mockReturnValue({ from: mockFrom });
+  });
+
+  it("queries maintainer and admin users", async () => {
+    const mockSelect = vi.fn().mockReturnThis();
+    const mockIn = vi.fn().mockResolvedValue({
+      data: [{ numericId: 1 }, { numericId: 2 }],
+      error: null,
+    });
+    const mockInsert = vi.fn().mockResolvedValue({ error: null });
+
+    mockFrom.mockImplementation((table: string) => {
+      if (table === "users") {
+        return { select: () => ({ in: mockIn }) };
+      }
+      if (table === "notifications") {
+        return { insert: mockInsert };
+      }
+      return {};
+    });
+
+    await notifyMaintainers({
+      type: "submission",
+      title: "New submission: Test Project",
+      body: "Test Project was submitted and is pending review.",
+      link: "/admin",
+      project_id: 123,
+    });
+
+    expect(mockFrom).toHaveBeenCalledWith("users");
+    expect(mockIn).toHaveBeenCalledWith("role", ["maintainer", "admin"]);
+  });
+
+  it("inserts notifications for each maintainer", async () => {
+    const mockSelect = vi.fn().mockReturnThis();
+    const mockIn = vi.fn().mockResolvedValue({
+      data: [{ numericId: 1 }, { numericId: 2 }],
+      error: null,
+    });
+    const mockInsert = vi.fn().mockResolvedValue({ error: null });
+
+    mockFrom.mockImplementation((table: string) => {
+      if (table === "users") {
+        return { select: () => ({ in: mockIn }) };
+      }
+      if (table === "notifications") {
+        return { insert: mockInsert };
+      }
+      return {};
+    });
+
+    await notifyMaintainers({
+      type: "submission",
+      title: "New submission: Test Project",
+      body: "Test Project body",
+      link: "/admin",
+      project_id: 123,
+    });
+
+    expect(mockFrom).toHaveBeenCalledWith("notifications");
+    expect(mockInsert).toHaveBeenCalledTimes(1);
+    const inserted = mockInsert.mock.calls[0][0];
+    expect(inserted).toHaveLength(2);
+    expect(inserted[0].user_id).toBe(1);
+    expect(inserted[0].type).toBe("submission");
+    expect(inserted[0].project_id).toBe(123);
+    expect(inserted[1].user_id).toBe(2);
+  });
+
+  it("does not fail when there are no maintainers", async () => {
+    mockFrom.mockImplementation((table: string) => {
+      if (table === "users") {
+        return {
+          select: () => ({ in: () => Promise.resolve({ data: [], error: null }) }),
+        };
+      }
+      return {};
+    });
+
+    await expect(
+      notifyMaintainers({
+        type: "submission",
+        title: "Test",
+        body: "Test body",
+        link: "/admin",
+      })
+    ).resolves.toBeUndefined();
+  });
+
+  it("handles notification failure gracefully (no throw)", async () => {
+    mockFrom.mockImplementation(() => {
+      throw new Error("DB error");
+    });
+
+    await expect(
+      notifyMaintainers({
+        type: "submission",
+        title: "Test",
+        body: "Test body",
+        link: "/admin",
+      })
+    ).resolves.toBeUndefined();
+  });
+});

--- a/web/src/__tests__/role-badge.test.ts
+++ b/web/src/__tests__/role-badge.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect, vi } from "vitest";
+
+vi.mock("@/context/AuthContext", () => ({
+  useAuth: vi.fn(),
+}));
+
+const { useAuth } = await import("@/context/AuthContext");
+
+describe("RoleBadge component behaviour", () => {
+  it("returns null when user is null (no render)", async () => {
+    (useAuth as any).mockReturnValue({ user: null });
+
+    const RoleBadge = (await import("@/components/RoleBadge")).default;
+    const result = RoleBadge();
+    expect(result).toBeNull();
+  });
+
+  it("returns null when user has no role", async () => {
+    (useAuth as any).mockReturnValue({ user: { username: "test" } });
+
+    const RoleBadge = (await import("@/components/RoleBadge")).default;
+    const result = RoleBadge();
+    expect(result).toBeNull();
+  });
+
+  it("renders role text for maintainer user", async () => {
+    (useAuth as any).mockReturnValue({
+      user: { role: "maintainer", username: "testmod" },
+    });
+
+    const RoleBadge = (await import("@/components/RoleBadge")).default;
+    const element = RoleBadge()!;
+    const props = (element as any).props;
+    expect(props.children).toBe("maintainer");
+  });
+
+  it("renders role text for admin user", async () => {
+    (useAuth as any).mockReturnValue({
+      user: { role: "admin", username: "testadmin" },
+    });
+
+    const RoleBadge = (await import("@/components/RoleBadge")).default;
+    const element = RoleBadge()!;
+    const props = (element as any).props;
+    expect(props.children).toBe("admin");
+  });
+
+  it("renders role text for contributor user", async () => {
+    (useAuth as any).mockReturnValue({
+      user: { role: "contributor", username: "testcontrib" },
+    });
+
+    const RoleBadge = (await import("@/components/RoleBadge")).default;
+    const element = RoleBadge()!;
+    const props = (element as any).props;
+    expect(props.children).toBe("contributor");
+  });
+});

--- a/web/src/app/api/projects/route.ts
+++ b/web/src/app/api/projects/route.ts
@@ -2,6 +2,7 @@ import {projectsCol, usersCol, ratingsCol, nextId} from "@/lib/db";
 import {getAuthUser} from "@/lib/auth";
 import {parseJsonBody} from "@/lib/validation/parse-body";
 import {createProjectSchema} from "@/lib/validation/schemas/projects";
+import {notifyMaintainers} from "@/lib/notifications";
 import slugify from "slugify";
 export const dynamic = "force-dynamic";
 
@@ -174,6 +175,17 @@ export async function POST(request: Request) {
 		};
 
 		await projectsCol.ref.doc(String(numericId)).set(project);
+
+		notifyMaintainers({
+			type: "submission",
+			title: `New submission: ${name}`,
+			body: `${name} was submitted by ${
+				auth.userId
+			} and is pending review.`,
+			link: `/admin`,
+			project_id: numericId,
+		});
+
 		return Response.json(
 			{project: {...project, id: numericId}},
 			{status: 201},

--- a/web/src/app/profile/page.tsx
+++ b/web/src/app/profile/page.tsx
@@ -5,6 +5,7 @@ import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { z } from "zod";
 import { useAuth } from "@/context/AuthContext";
+import RoleBadge from "@/components/RoleBadge";
 import Link from "next/link";
 import {
   Form,
@@ -180,7 +181,7 @@ export default function ProfilePage() {
             <h1 className="font-display font-bold text-3xl text-starlight">{user.username}</h1>
             <div className="flex items-center gap-3 text-sm text-ash mt-0.5">
               <span>{user.email || "No email"}</span>
-              <span className="tag tag-nova text-xs">{user.role}</span>
+              <RoleBadge />
               {user.created_at && (
                 <span>Joined {new Date(user.created_at).toLocaleDateString()}</span>
               )}

--- a/web/src/components/Navbar.tsx
+++ b/web/src/components/Navbar.tsx
@@ -4,6 +4,7 @@ import Link from "next/link";
 import Image from "next/image";
 import {useAuth} from "@/context/AuthContext";
 import {hasMinRole} from "@/lib/roles";
+import RoleBadge from "@/components/RoleBadge";
 import {useState} from "react";
 
 export default function Navbar() {
@@ -91,6 +92,7 @@ export default function Navbar() {
 								<span className="text-sm font-medium text-moonlight">
 									{user.username}
 								</span>
+								<RoleBadge />
 							</Link>
 								<button
 									onClick={logout}

--- a/web/src/components/RoleBadge.tsx
+++ b/web/src/components/RoleBadge.tsx
@@ -1,0 +1,22 @@
+"use client";
+
+import { useAuth } from "@/context/AuthContext";
+
+const ROLE_STYLES: Record<string, string> = {
+  admin: "tag-nova",
+  maintainer: "tag-solar",
+  contributor: "tag-plasma",
+};
+
+export default function RoleBadge() {
+  const { user } = useAuth();
+  if (!user || !user.role) return null;
+
+  const style = ROLE_STYLES[user.role] ?? "tag-nova";
+
+  return (
+    <span className={`tag ${style} text-[10px] leading-none`}>
+      {user.role}
+    </span>
+  );
+}

--- a/web/src/lib/firebase.ts
+++ b/web/src/lib/firebase.ts
@@ -11,6 +11,7 @@ const TABLE_BY_COLLECTION: Record<string, string> = {
 	auth_challenges: "auth_challenges",
 	counters: "counters",
 	submission_notes: "submission_notes",
+	notifications: "notifications",
 };
 
 function resolveTable(collection: string): string {

--- a/web/src/lib/notifications.ts
+++ b/web/src/lib/notifications.ts
@@ -1,0 +1,44 @@
+import { getSupabase } from "./firebase";
+
+interface NotificationPayload {
+  type: string;
+  title: string;
+  body: string;
+  link: string;
+  project_id?: number;
+}
+
+export async function notifyMaintainers(
+  payload: NotificationPayload,
+): Promise<void> {
+  try {
+    const supabase = getSupabase();
+
+    const { data: maintainers, error } = await supabase
+      .from("users")
+      .select("numericId")
+      .in("role", ["maintainer", "admin"]);
+
+    if (error) throw error;
+    if (!maintainers || maintainers.length === 0) return;
+
+    const notifications = maintainers.map((u: { numericId: number }) => ({
+      user_id: u.numericId,
+      type: payload.type,
+      title: payload.title,
+      body: payload.body,
+      link: payload.link,
+      project_id: payload.project_id ?? null,
+      read: false,
+      created_at: new Date().toISOString(),
+    }));
+
+    const { error: insertError } = await supabase
+      .from("notifications")
+      .insert(notifications);
+
+    if (insertError) throw insertError;
+  } catch (err) {
+    console.error("Failed to notify maintainers:", err);
+  }
+}

--- a/web/vitest.config.ts
+++ b/web/vitest.config.ts
@@ -1,0 +1,15 @@
+import { defineConfig } from "vitest/config";
+import path from "path";
+
+export default defineConfig({
+  resolve: {
+    alias: {
+      "@": path.resolve(__dirname, "./src"),
+    },
+  },
+  test: {
+    environment: "node",
+    globals: true,
+    include: ["**/*.test.{ts,tsx}"],
+  },
+});


### PR DESCRIPTION
# Summary

Closes #245
Closes #246

## What changed
- `web/data/supabase/007_add_notifications.sql` — New migration: creates `notifications` table for in-app notifications
- `web/src/lib/notifications.ts` — New notification service: `notifyMaintainers()` queries users with `maintainer` or `admin` role and inserts notification records
- `web/src/app/api/projects/route.ts` — Added fire-and-forget notification call after project submission (non-blocking; failure never fails submission)
- `web/src/components/RoleBadge.tsx` — New component: renders role name with role-specific CSS tag styling (`tag-nova` for admin, `tag-solar` for maintainer, `tag-plasma` for contributor)
- `web/src/components/Navbar.tsx` — Added RoleBadge next to username in the auth section
- `web/src/app/profile/page.tsx` — Replaced hardcoded `tag-nova` role tag with `<RoleBadge />` component for dynamic styling
- `web/src/lib/firebase.ts` — Added `notifications` to the TABLE_BY_COLLECTION mapping
- `README.md` — Added "Roles & Permissions" section with full permission matrix table for all three roles and assignment instructions
- `docs/MAINTAINERS.md` — Updated Roles & Permissions table to include Maintainer role, added hierarchy explanation and code reference links
- `web/vitest.config.ts` — New vitest configuration file
- `web/package.json` — Added test script
- `web/eslint.config.mjs` — Added test directory to global ignores
- `web/src/__tests__/notifications.test.ts` — Tests: notification sent to maintainers, handles empty results, handles DB errors
- `web/src/__tests__/role-badge.test.ts` — Tests: badge renders for each role, returns null for unauthenticated/missing role
- `web/src/__tests__/docs.test.ts` — Tests: docs contain roles/permissions heading, table, and assignment descriptions

## Notification mechanism
**In-app notifications** — no email infrastructure exists in the codebase. A `notifications` table was added to Supabase (migration `007_add_notifications.sql`). When a project is submitted, `notifyMaintainers()` queries all users with `maintainer` or `admin` roles and inserts a notification record for each. The call is fire-and-forget (not awaited), so notification failure never blocks or fails the submission.

## Role badge locations
- **Navbar** (`web/src/components/Navbar.tsx`) — next to the username, visible in the desktop auth section
- **Profile page** (`web/src/app/profile/page.tsx`) — in the user header next to email

## How to verify
1. Submit a project — confirm maintainer receives notification (check `notifications` table for new rows)
2. View a maintainer's profile — confirm role badge is visible with "maintainer" text
3. View nav as maintainer — confirm badge is present next to username
4. View as guest — confirm no badge is rendered anywhere
5. Run `npm test` — all 16 tests pass

