### PR TITLE
feat: live financial sparkline on project cards (#201)

### DIFF
--- a/web/src/app/api/financials/[projectId]/snapshots/route.ts
+++ b/web/src/app/api/financials/[projectId]/snapshots/route.ts
@@ -1,0 +1,87 @@
+import {financialSnapshotsCol, projectsCol} from "@/lib/db";
+
+export const dynamic = "force-dynamic";
+
+/**
+ * GET /api/financials/[projectId]/snapshots
+ *
+ * Returns the most recent financial snapshots for a project, ordered
+ * oldest-first so the client can draw a left-to-right sparkline.
+ *
+ * Query params:
+ *   limit  – number of snapshots to return (default 20, max 100)
+ *
+ * Response: { snapshots: Array<{ id, created_at, xlm_balance: number }> }
+ *
+ * Each item exposes the XLM balance extracted from snapshot_data.balances
+ * (the native asset is listed as asset_type "native" in Stellar payloads).
+ * If the project has no linked account or no snapshots the response is an
+ * empty array — the UI renders a graceful empty state.
+ */
+export async function GET(
+	request: Request,
+	{params}: {params: Promise<{projectId: string}>},
+) {
+	const {projectId} = await params;
+
+	// Validate project exists
+	const projectDoc = await projectsCol.ref.doc(projectId).get();
+	if (!projectDoc.exists) {
+		return Response.json({error: "Project not found"}, {status: 404});
+	}
+
+	// Parse optional limit query param
+	const url = new URL(request.url);
+	const rawLimit = parseInt(url.searchParams.get("limit") ?? "20", 10);
+	const limit = Number.isNaN(rawLimit)
+		? 20
+		: Math.min(Math.max(rawLimit, 1), 100);
+
+	try {
+		// Fetch the `limit` most recent snapshots, then reverse for oldest-first
+		const snapshot = await financialSnapshotsCol.ref
+			.where("project_id", "==", Number(projectId))
+			.orderBy("created_at", "desc")
+			.limit(limit)
+			.get();
+
+		const snapshots = snapshot.docs
+			.map((doc) => {
+				const row = doc.data();
+				// snapshot_data is the JSONB payload stored by the stellar service
+				// Shape: { balances: [{asset_type, asset_code, balance}], ... }
+				const data =
+					typeof row.snapshot_data === "object" && row.snapshot_data !== null
+						? (row.snapshot_data as Record<string, unknown>)
+						: {};
+
+				const balances = Array.isArray(data.balances)
+					? (data.balances as {asset_type?: string; asset_code?: string; balance?: string}[])
+					: [];
+
+				// Find the XLM (native) balance
+				const nativeEntry = balances.find(
+					(b) => b.asset_type === "native" || b.asset_code === "XLM",
+				);
+				const xlm_balance = nativeEntry
+					? parseFloat(nativeEntry.balance ?? "0")
+					: 0;
+
+				return {
+					id: row.id as number,
+					created_at: row.created_at as string,
+					xlm_balance,
+				};
+			})
+			// Reverse so the array goes oldest → newest (left → right on the chart)
+			.reverse();
+
+		return Response.json({snapshots});
+	} catch (err) {
+		console.error("Snapshots fetch error:", err);
+		return Response.json(
+			{error: "Failed to fetch snapshots"},
+			{status: 500},
+		);
+	}
+}

--- a/web/src/components/ProjectCard.tsx
+++ b/web/src/components/ProjectCard.tsx
@@ -1,6 +1,8 @@
 "use client";
 
 import Link from "next/link";
+import {useEffect, useState} from "react";
+import Sparkline from "@/components/Sparkline";
 
 interface ProjectCardProps {
   project: {
@@ -33,9 +35,44 @@ const categoryColors: Record<string, string> = {
   other: "tag-nova",
 };
 
+/**
+ * Fetches the most-recent XLM balance snapshots for a project and returns
+ * them as a plain number array suitable for <Sparkline />.
+ */
+function useSparklineData(projectId: number) {
+  const [values, setValues] = useState<number[] | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    fetch(`/api/financials/${projectId}/snapshots?limit=20`)
+      .then((res) => (res.ok ? res.json() : Promise.reject(res.status)))
+      .then((data: {snapshots: {xlm_balance: number}[]}) => {
+        if (cancelled) return;
+        const numbers = (data.snapshots ?? []).map((s) => s.xlm_balance);
+        setValues(numbers);
+      })
+      .catch(() => {
+        if (!cancelled) setValues([]); // treat errors as no data
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [projectId]);
+
+  return values; // null = loading, [] = no data, number[] = data ready
+}
+
 export default function ProjectCard({ project, index = 0 }: ProjectCardProps) {
   const colorClass = categoryColors[project.category?.toLowerCase()] || "tag-nova";
   const tags = project.tags ? project.tags.split(",").slice(0, 3) : [];
+  const sparkValues = useSparklineData(project.id);
+
+  // Determine trend label for the sparkline footer chip
+  const hasSpark = sparkValues !== null && sparkValues.length >= 2;
+  const isUp =
+    hasSpark && sparkValues[sparkValues.length - 1] >= sparkValues[0];
 
   return (
     <Link
@@ -70,6 +107,28 @@ export default function ProjectCard({ project, index = 0 }: ProjectCardProps) {
             <p className="text-xs text-ash mt-0.5">by {project.username}</p>
           )}
         </div>
+
+        {/* Sparkline — shown only when data is ready and has ≥2 points */}
+        {hasSpark ? (
+          <div className="shrink-0 flex flex-col items-end gap-0.5">
+            <Sparkline values={sparkValues} width={80} height={28} />
+            <span
+              className={`text-[10px] font-semibold leading-none ${
+                isUp ? "text-aurora-bright" : "text-supernova"
+              }`}
+              aria-label={isUp ? "Balance trending up" : "Balance trending down"}
+            >
+              {isUp ? "▲" : "▼"} XLM
+            </span>
+          </div>
+        ) : sparkValues === null ? (
+          /* Loading placeholder — fixed dimensions prevent layout shift */
+          <div
+            className="skeleton shrink-0 rounded"
+            style={{width: 80, height: 28}}
+            aria-hidden="true"
+          />
+        ) : null /* no data — render nothing, no layout shift */}
       </div>
 
       {/* Description */}

--- a/web/src/components/Sparkline.tsx
+++ b/web/src/components/Sparkline.tsx
@@ -1,0 +1,87 @@
+"use client";
+
+interface SparklineProps {
+  /** Ordered list of numeric values (oldest → newest). */
+  values: number[];
+  width?: number;
+  height?: number;
+  className?: string;
+}
+
+/**
+ * Lightweight pure-SVG sparkline — no external chart library.
+ *
+ * Renders a smooth polyline + a subtle area fill. The stroke colour shifts
+ * from aurora-green (up/flat trend) to supernova-red (down trend) so a
+ * glance tells users whether a project's on-chain balance is growing.
+ */
+export default function Sparkline({
+  values,
+  width = 80,
+  height = 28,
+  className = "",
+}: SparklineProps) {
+  // Need at least 2 points to draw a line
+  if (!values || values.length < 2) return null;
+
+  const min = Math.min(...values);
+  const max = Math.max(...values);
+  const range = max - min || 1; // avoid /0 when all values are equal
+
+  const padX = 2;
+  const padY = 3;
+  const drawW = width - padX * 2;
+  const drawH = height - padY * 2;
+
+  // Map value → SVG coordinate (y is flipped)
+  const toX = (i: number) => padX + (i / (values.length - 1)) * drawW;
+  const toY = (v: number) => padY + drawH - ((v - min) / range) * drawH;
+
+  const points = values.map((v, i) => `${toX(i).toFixed(2)},${toY(v).toFixed(2)}`);
+  const polyline = points.join(" ");
+
+  // Closed path for the area fill (down to baseline, back to start)
+  const baseline = padY + drawH;
+  const areaPath =
+    `M ${toX(0).toFixed(2)},${baseline} ` +
+    points.map((p) => `L ${p}`).join(" ") +
+    ` L ${toX(values.length - 1).toFixed(2)},${baseline} Z`;
+
+  // Trend: compare last value to first
+  const isUp = values[values.length - 1] >= values[0];
+  // aurora = #10b981 (green), supernova = #ef4444 (red)
+  const strokeColor = isUp ? "var(--aurora)" : "var(--supernova)";
+  const fillColor = isUp ? "rgba(16,185,129,0.12)" : "rgba(239,68,68,0.10)";
+
+  return (
+    <svg
+      width={width}
+      height={height}
+      viewBox={`0 0 ${width} ${height}`}
+      aria-hidden="true"
+      className={className}
+      style={{ display: "block", overflow: "visible" }}
+    >
+      {/* Area fill */}
+      <path d={areaPath} fill={fillColor} />
+
+      {/* Trend line */}
+      <polyline
+        points={polyline}
+        fill="none"
+        stroke={strokeColor}
+        strokeWidth="1.5"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+
+      {/* Dot at the latest data point */}
+      <circle
+        cx={toX(values.length - 1).toFixed(2)}
+        cy={toY(values[values.length - 1]).toFixed(2)}
+        r="2"
+        fill={strokeColor}
+      />
+    </svg>
+  );
+}


### PR DESCRIPTION
## Summary

Closes #201.

Renders a small balance-over-time sparkline on each `ProjectCard` sourced from `financial_snapshots`.

---

## Changes

### `web/src/components/Sparkline.tsx` (new)
- Pure SVG sparkline — no external chart library
- Accepts an ordered `values: number[]` array (oldest → newest)
- Stroke colour: **aurora-green** when trend is up/flat, **supernova-red** when down
- Area fill + endpoint dot for visual clarity

### `web/src/app/api/financials/[projectId]/snapshots/route.ts` (new)
- `GET /api/financials/[projectId]/snapshots?limit=20`
- Queries `financial_snapshots` table filtered by `project_id`
- Extracts XLM native balance from `snapshot_data.balances`
- Returns results oldest-first for correct left→right chart rendering
- Returns `{ snapshots: [] }` (never errors) when no data exists

### `web/src/components/ProjectCard.tsx` (modified)
- Added `useSparklineData` hook — fetches snapshots once per card mount, cancels on unmount
- Three explicit states, zero layout shift:

| State | Renders |
|---|---|
| `null` — fetching | Fixed 80×28 `.skeleton` shimmer |
| `[]` — no data / error | Nothing (no reserved space) |
| `number[]` ≥2 points | `<Sparkline />` + ▲/▼ XLM trend chip |

---

## Testing

- `npm run build` passes: TypeScript clean, all 17 pages compiled
- New route `/api/financials/[projectId]/snapshots` appears in build output