### PR TITLE
docs: add eleven-smg to contributors

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -373,6 +373,17 @@ Replace `YOUR_GITHUB_USERNAME`, `Your Name`, `YOUR_X_HANDLE`, and the role/proje
         <br />
         <sub>Researcher — Stellar GreenPay</sub>
     </div>
+        <td align="center">
+      <a href="https://github.com/eleven-smg">
+        <img src="https://github.com/eleven-smg.png" width="80" alt="eleven-smg" style="border-radius:50%" />
+        <br />
+        <sub><b>eleven-smg</b></sub>
+      </a>
+      <br />
+      <a href="https://github.com/eleven-smg"><img src="https://img.shields.io/badge/-GitHub-181717?logo=github&logoColor=white&style=flat-square" alt="GitHub" /></a>
+      <br />
+      <sub>Researcher — Boundless Bounty</sub>
+    </td>
     <!-- Add your <td> above this line -->
   </tr>
 </table>


### PR DESCRIPTION
Fresh PR against current `main`, as invited in #282.

> Closing this PR as part of a repository cleanup — this is not a reflection on the quality of the contribution. If you'd still like this change merged, please feel free to reopen the PR or open a fresh one against the current `main`. Thanks for contributing to Stellar Wave Hub!

## What

Adds my contributor entry to `CONTRIBUTORS.md` for the Stellar Wave project I researched and submitted to the Hub.

- **Project researched:** Boundless Bounty
- **On-chain verification:** Soroban contract `CA3VZ…VPHN` on Stellar testnet
- **Role line:** `Researcher — Boundless Bounty`

## Scope

- 1 file changed, 11 additions, 0 deletions
- Documentation only — no code, no config, no behavior change
- Entry added as a table cell inside the existing contributors table, directly above the "Add your entry above this line" marker comment
- Surrounding entries are left untouched, so the diff is limited to my own block

## Rebase status

Verified against current `main`: the rest of `CONTRIBUTORS.md` is unchanged from this branch's base, so this applies cleanly with no conflicts.

## Note for reviewers

Same content as #282, which was closed during repository cleanup rather than for any issue with the change itself. Authored from my personal account **@eleven-smg**; the branch is hosted on a fork under my `eleven-smgg` organisation, which is why the head reference shows that name.

Closes #65